### PR TITLE
feat(training): filter sub-12h markets, bump retrain market count to …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       MODEL_PORT: "8000"
       RETRAIN_MAX_AGE_HOURS: "24"
       RETRAIN_ON_SCHEDULE: "true"
+      RETRAIN_MARKETS: "3000"
     volumes:
       - model:/model
     ports:

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -262,7 +262,8 @@ def _extract_snapshot(prices: np.ndarray, timestamps: np.ndarray,
 
     # Only keep snapshots within the deployment window: bot bets at 3-14d remaining.
     # Snapshots outside this range teach the model patterns that never appear in live.
-    if days_to_expiry > 14.0:
+    # Lower bound: sub-12h markets (5-min Bitcoin, hourly) are noise — never appear in live.
+    if days_to_expiry > 14.0 or days_to_expiry < 0.5:
         return None
 
     # Category detection — must match live Rust logic (category + question, same keywords)

--- a/scripts/serve_model.py
+++ b/scripts/serve_model.py
@@ -38,6 +38,7 @@ MODEL_PATH = Path(MODEL_DIR) / "ensemble.joblib"
 SCALER_PATH = Path(MODEL_DIR) / "scaler.joblib"
 MAX_AGE_HOURS = int(os.environ.get("RETRAIN_MAX_AGE_HOURS", "24"))
 RETRAIN_ON_SCHEDULE = os.environ.get("RETRAIN_ON_SCHEDULE", "true").lower() == "true"
+RETRAIN_MARKETS = int(os.environ.get("RETRAIN_MARKETS", "3000"))
 
 FEATURE_NAMES = [
     "yes_price", "momentum_1h", "momentum_24h", "volatility_24h", "rsi",
@@ -101,7 +102,7 @@ def _run_retrain():
     try:
         log.info("Retrain: fetching data...")
         subprocess.run(
-            [sys.executable, "fetch_data.py", "--markets", "1000",
+            [sys.executable, "fetch_data.py", "--markets", str(RETRAIN_MARKETS),
              "--output", f"{MODEL_DIR}/training_data.json"],
             check=True, capture_output=True, text=True,
         )


### PR DESCRIPTION
…3000

- Skip snapshots with days_to_expiry < 0.5 (12h) to exclude 5-min Bitcoin and hourly markets that never appear in live betting window
- Make retrain market count configurable via RETRAIN_MARKETS env var (default 3000) to take advantage of Hetzner's capacity vs 1000 previously