### PR TITLE
feat: add NEWS_ENABLED flag, disable news by default when model is ac…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ OPENAI_API_KEY=your_openai_api_key
 # Optional (defaults shown)
 # SCAN_INTERVAL_MINS=30
 # NEWS_SCAN_INTERVAL_MINS=10
+# NEWS_ENABLED=false
 # SLIPPAGE_PCT=0.01
 # FEE_PCT=0.02
 # MIN_VOLUME=1000.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,12 @@ pub struct AppConfig {
     #[config(env = "NEWS_SCAN_INTERVAL_MINS", default = 10)]
     pub news_scan_interval_mins: u64,
 
+    /// Enable news fetching and embedding-based matching.
+    /// When the model sidecar is active, news has no effect on predictions —
+    /// disable to save RSS + OpenAI embedding costs.
+    #[config(env = "NEWS_ENABLED", default = false)]
+    pub news_enabled: bool,
+
     // --- Betting ---
     /// Slippage assumption as a fraction (0.01 = 1%).
     #[config(env = "SLIPPAGE_PCT", default = 0.01)]

--- a/src/live.rs
+++ b/src/live.rs
@@ -206,7 +206,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
              📊 Open: {open_count} | Record: {wins}W/{losses}L\n\n\
              {strat_details}\n\n\
              ⚙️ *Config:*\n\
-             ⏱ News: every {news_min}min | Housekeeping: every {hk_min}min\n\
+             ⏱ News: {news_status} | Housekeeping: every {hk_min}min\n\
              🎯 Max {max_sig} signals/day (per strategy) | Kelly: {kelly:.0}%\n\
              🔍 Min edge: {edge:.0}% | Min volume: ${vol:.0}\n\
              🧠 Pipeline: {pipeline}\n\
@@ -215,7 +215,11 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
             wins = resolved.iter().filter(|b| b.won == Some(true)).count(),
             losses = resolved.iter().filter(|b| b.won == Some(false)).count(),
             strat_details = strat_lines.join("\n"),
-            news_min = cfg.news_scan_interval_mins,
+            news_status = if cfg.news_enabled {
+                format!("every {}min", cfg.news_scan_interval_mins)
+            } else {
+                "disabled".to_string()
+            },
             hk_min = cfg.scan_interval_mins,
             max_sig = strategies
                 .iter()
@@ -275,7 +279,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
         }
     });
 
-    // Spawn news scanning loop (faster cycle)
+    // Spawn news scanning loop (faster cycle) — disabled when NEWS_ENABLED=false
     let ns_portfolio = Arc::clone(&portfolio);
     let ns_notifier = Arc::clone(&notifier);
     let ns_scanner = Arc::clone(&scanner);
@@ -283,6 +287,11 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
     let ns_stats = Arc::clone(&stats);
     let ns_strategies = Arc::clone(&strategies);
     let news_scan = tokio::spawn(async move {
+        if !ns_cfg.news_enabled {
+            tracing::info!("News cycle disabled (NEWS_ENABLED=false) — parked");
+            std::future::pending::<()>().await;
+            return;
+        }
         let mut seen_headlines: std::collections::HashSet<String> =
             std::collections::HashSet::new();
 

--- a/src/scanner/live.rs
+++ b/src/scanner/live.rs
@@ -1013,52 +1013,51 @@ impl LiveScanner {
             "Top model candidates passed liquidity"
         );
 
-        // Step 4: Fetch news and match to top candidates (boost, not gate)
-        // No cross-cycle headline dedup for model-first — the 4h freshness
-        // window handles staleness, and the same headline may be relevant
-        // to different top candidates across cycles.
-        let (mut news, source_counts) = self.news.fetch_all().await;
-        let news_total = news.len();
+        // Step 4: Optionally fetch news and match to top candidates (Telegram context only).
+        // News has no effect on model predictions — disable via NEWS_ENABLED=false to save
+        // RSS + OpenAI embedding costs when running with a model sidecar.
+        let (news_total, news_new, news_matched, news_by_market) = if self.cfg.news_enabled {
+            let (mut news, _source_counts) = self.news.fetch_all().await;
+            let news_total = news.len();
 
-        let freshness_cutoff = chrono::Utc::now() - chrono::Duration::hours(4);
-        news.retain(|item| {
-            item.published
-                .map(|p| p >= freshness_cutoff)
-                .unwrap_or(true)
-        });
+            let freshness_cutoff = chrono::Utc::now() - chrono::Duration::hours(4);
+            news.retain(|item| {
+                item.published
+                    .map(|p| p >= freshness_cutoff)
+                    .unwrap_or(true)
+            });
+            dedup_news(&mut news);
+            let news_new = news.len();
 
-        // Dedup within this batch only (same headline from multiple RSS feeds)
-        dedup_news(&mut news);
-
-        let news_new = news.len();
-
-        // Match news to candidate markets only (not all eligible — saves embedding cost)
-        let candidate_markets: Vec<GammaMarket> =
-            candidates.iter().map(|c| c.market.clone()).collect();
-        let news_matches = if !news.is_empty() {
-            self.news
-                .match_to_markets(&news, &candidate_markets)
-                .await
-                .unwrap_or_default()
+            let candidate_markets: Vec<GammaMarket> =
+                candidates.iter().map(|c| c.market.clone()).collect();
+            let news_matches = if !news.is_empty() {
+                self.news
+                    .match_to_markets(&news, &candidate_markets)
+                    .await
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            let news_matched = news_matches.len();
+            let mut by_market: std::collections::HashMap<String, NewsMatch> =
+                std::collections::HashMap::new();
+            for nm in news_matches {
+                by_market.insert(nm.market.market_id.clone(), nm);
+            }
+            tracing::info!(
+                news_total,
+                news_new,
+                news_matched,
+                "News fetched and matched"
+            );
+            (news_total, news_new, news_matched, by_market)
         } else {
-            Vec::new()
+            tracing::debug!("News disabled (NEWS_ENABLED=false) — skipping fetch");
+            (0, 0, 0, std::collections::HashMap::new())
         };
-
-        // Build lookup: market_id → matched news
-        let mut news_by_market: std::collections::HashMap<String, &NewsMatch> =
-            std::collections::HashMap::new();
-        for nm in &news_matches {
-            news_by_market.insert(nm.market.market_id.clone(), nm);
-        }
-
-        let news_matched = news_matches.len();
-
-        tracing::info!(
-            news_total,
-            news_new,
-            news_matched,
-            "News fetched and matched to top candidates"
-        );
+        let source_counts: Vec<(String, usize)> = Vec::new();
+        let news_by_market = &news_by_market;
 
         // Step 5: Build signals from model candidates + optional news boost
         let mut signals = Vec::new();


### PR DESCRIPTION
…tive

Analysis: in MODEL-FIRST path (sidecar active), news is fetched and matched but has zero effect on predictions — from_market_and_news() ignores news params since they were dropped from the feature vector. News only populated Telegram notification context, at the cost of ~15 RSS fetches + OpenAI embedding calls per scan cycle.

NEWS_ENABLED defaults to false. Set NEWS_ENABLED=true to re-enable. The news-first/LLM path still requires news and ignores this flag.