### PR TITLE
chore: replace deprecated on_event with lifespan handler

### DIFF
--- a/scripts/serve_model.py
+++ b/scripts/serve_model.py
@@ -29,6 +29,8 @@ from pathlib import Path
 import joblib
 import numpy as np
 import pandas as pd
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
@@ -126,7 +128,22 @@ FEATURE_NAMES = [
 # Category columns subject to target encoding (binary → historical YES rate)
 CATEGORY_COLS = ["is_crypto"]
 
-app = FastAPI(title="Polymarket ML Sidecar")
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    if not MODEL_PATH.exists():
+        _retrain_if_stale()
+    else:
+        load_model()
+
+    if RETRAIN_ON_SCHEDULE:
+        t = threading.Thread(target=_schedule_loop, daemon=True)
+        t.start()
+        log.info("retrain.scheduled: checking every 1h, max age %dh", MAX_AGE_HOURS)
+
+    yield
+
+
+app = FastAPI(title="Polymarket ML Sidecar", lifespan=_lifespan)
 
 # Global state
 model = None
@@ -357,17 +374,6 @@ def _schedule_loop():
             log.error("retrain.schedule_error: %s", e)
 
 
-@app.on_event("startup")
-def startup():
-    if not MODEL_PATH.exists():
-        _retrain_if_stale()
-    else:
-        load_model()
-
-    if RETRAIN_ON_SCHEDULE:
-        t = threading.Thread(target=_schedule_loop, daemon=True)
-        t.start()
-        log.info("retrain.scheduled: checking every 1h, max age %dh", MAX_AGE_HOURS)
 
 
 class FeatureMap(BaseModel):


### PR DESCRIPTION
## Summary

- Replaces `@app.on_event("startup")` with the `asynccontextmanager` lifespan pattern
- Eliminates the `DeprecationWarning` emitted on every sidecar startup
- No behaviour change — same startup logic (load model, start schedule thread)