### PR TITLE
fix: clear model globals on schema mismatch, add retrain step to status

### DIFF
--- a/scripts/serve_model.py
+++ b/scripts/serve_model.py
@@ -149,6 +149,7 @@ class _RetrainState:
         self.started_at: str | None = None
         self.finished_at: str | None = None
         self.error: str | None = None
+        self.step: str | None = None  # current progress step
         self.lock = threading.Lock()
 
 
@@ -174,6 +175,9 @@ def load_model():
                 scaler_features,
                 FEATURE_NAMES,
             )
+            # Clear globals so predict returns 503 instead of crashing with 500.
+            model = None
+            scaler = None
             threading.Thread(target=_force_retrain, daemon=True).start()
             return False
 
@@ -202,6 +206,7 @@ def _run_retrain():
     _retrain.started_at = datetime.now(timezone.utc).isoformat()
     _retrain.finished_at = None
     _retrain.error = None
+    _retrain.step = "fetch"
 
     try:
         log.info("retrain.fetch_start: markets=%d", RETRAIN_MARKETS)
@@ -214,6 +219,7 @@ def _run_retrain():
             fetch_args += ["--db", DATABASE_URL]
         subprocess.run(fetch_args, check=True, capture_output=True, text=True)
 
+        _retrain.step = "train"
         log.info("retrain.train_start")
         subprocess.run(
             [sys.executable, "train_model.py",
@@ -222,8 +228,10 @@ def _run_retrain():
             check=True, capture_output=True, text=True,
         )
 
+        _retrain.step = "load"
         load_model()
         _retrain.status = RetrainStatus.success
+        _retrain.step = None
         log.info("retrain.complete")
     except subprocess.CalledProcessError as e:
         _retrain.status = RetrainStatus.failed
@@ -567,6 +575,7 @@ class RetrainRequest(BaseModel):
 
 class RetrainStatusResponse(BaseModel):
     status: RetrainStatus
+    step: str | None = None
     model_age_hours: float | None = None
     max_age_hours: int = MAX_AGE_HOURS
     started_at: str | None = None
@@ -612,6 +621,7 @@ def retrain_warmstart():
 def retrain_status():
     return RetrainStatusResponse(
         status=_retrain.status,
+        step=_retrain.step,
         model_age_hours=model_age_hours(),
         started_at=_retrain.started_at,
         finished_at=_retrain.finished_at,


### PR DESCRIPTION
## Summary

- **Bug**: `load_model()` assigned `model`/`scaler` globals *before* the schema mismatch check. Returning `False` left them pointing at the stale artifact, so `predict` saw a non-`None` model and crashed with 500. Now clears both to `None` before returning.
- **Observability**: `_RetrainState` gains a `step` field (`fetch` → `train` → `load` → `null`). Exposed on `GET /retrain/status` as `step` so you can see where a long retrain is at any moment.

## Test plan

- [ ] After deploy: `predict` returns 503 during retrain instead of 500
- [ ] `curl /retrain/status` shows `"step": "fetch"` while data is being fetched, `"train"` while training