### PR TITLE
fix: stop exposing internal service ports to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_PASSWORD: bot
     volumes:
       - pgdata:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U bot -d polymarket"]
       interval: 5s
@@ -31,8 +29,6 @@ services:
       RETRAIN_MARKETS: "3000"
     volumes:
       - model:/model
-    ports:
-      - "8000:8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Remove host port mappings for `postgres` (5432) and `model-server` (8000)
- Both services are only accessed by other containers via the internal Docker network
- Eliminates internet scanner noise and reduces attack surface

## Test plan
- [ ] `docker compose up -d` — all services start and communicate normally
- [ ] Bot connects to postgres and model-server without issues
- [ ] Port 8000 and 5432 are no longer reachable from the host/internet