### PR TITLE
feat: separate bet scan cycle from news cycle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,10 @@ pub struct AppConfig {
     #[config(env = "NEWS_SCAN_INTERVAL_MINS", default = 10)]
     pub news_scan_interval_mins: u64,
 
+    /// Bet scan loop interval in minutes (market scoring + betting).
+    #[config(env = "BET_SCAN_INTERVAL_MINS", default = 10)]
+    pub bet_scan_interval_mins: u64,
+
     /// Enable news fetching and embedding-based matching.
     /// When the model sidecar is active, news has no effect on predictions —
     /// disable to save RSS + OpenAI embedding costs.

--- a/src/cycles/bet_scan.rs
+++ b/src/cycles/bet_scan.rs
@@ -13,7 +13,7 @@ use crate::storage::postgres::PgPortfolio;
 use crate::strategy::StrategyProfile;
 use crate::telegram::notifier::TelegramNotifier;
 
-pub async fn news_scan_cycle(
+pub async fn bet_scan_cycle(
     portfolio: &PgPortfolio,
     notifier: &TelegramNotifier,
     scanner: &LiveScanner,
@@ -30,7 +30,7 @@ pub async fn news_scan_cycle(
     let bankroll = portfolio.bankroll().await?;
     tracing::info!(
         bankroll = format_args!("€{bankroll:.2}"),
-        "Starting news scan..."
+        "Starting bet scan..."
     );
 
     let mut skip_ids = portfolio.open_bet_market_ids().await?;
@@ -320,7 +320,7 @@ pub async fn news_scan_cycle(
             }
         }
         Err(e) => {
-            tracing::error!(err = %e, "News scan failed");
+            tracing::error!(err = %e, "Bet scan failed");
         }
     }
 
@@ -329,7 +329,7 @@ pub async fn news_scan_cycle(
     tracing::info!(
         signals_today = signals_today,
         open_bets = open_count,
-        "News scan cycle complete"
+        "Bet scan cycle complete"
     );
     Ok(())
 }

--- a/src/cycles/mod.rs
+++ b/src/cycles/mod.rs
@@ -1,11 +1,11 @@
 mod alerts;
+mod bet_scan;
 pub mod copy_trade;
 mod heartbeat;
 mod housekeeping;
-mod news;
 
 pub use alerts::alert_loop;
+pub use bet_scan::bet_scan_cycle;
 pub use copy_trade::copy_trade_cycle;
 pub use heartbeat::heartbeat_cycle;
 pub use housekeeping::housekeeping_cycle;
-pub use news::news_scan_cycle;

--- a/src/live.rs
+++ b/src/live.rs
@@ -74,7 +74,7 @@ pub async fn notify_owner(notifier: &TelegramNotifier, message: &str) {
 
 pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
     tracing::info!(
-        news_interval_mins = cfg.news_scan_interval_mins,
+        bet_scan_interval_mins = cfg.bet_scan_interval_mins,
         housekeeping_interval_mins = cfg.scan_interval_mins,
         "Polymarket Signal Bot starting (dual-loop)..."
     );
@@ -206,7 +206,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
              📊 Open: {open_count} | Record: {wins}W/{losses}L\n\n\
              {strat_details}\n\n\
              ⚙️ *Config:*\n\
-             ⏱ News: {news_status} | Housekeeping: every {hk_min}min\n\
+             ⏱ Bet scan: every {bet_min}min | News: {news_status} | HK: every {hk_min}min\n\
              🎯 Max {max_sig} signals/day (per strategy) | Kelly: {kelly:.0}%\n\
              🔍 Min edge: {edge:.0}% | Min volume: ${vol:.0}\n\
              🧠 Pipeline: {pipeline}\n\
@@ -215,6 +215,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
             wins = resolved.iter().filter(|b| b.won == Some(true)).count(),
             losses = resolved.iter().filter(|b| b.won == Some(false)).count(),
             strat_details = strat_lines.join("\n"),
+            bet_min = cfg.bet_scan_interval_mins,
             news_status = if cfg.news_enabled {
                 format!("every {}min", cfg.news_scan_interval_mins)
             } else {
@@ -279,39 +280,34 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
         }
     });
 
-    // Spawn news scanning loop (faster cycle) — disabled when NEWS_ENABLED=false
-    let ns_portfolio = Arc::clone(&portfolio);
-    let ns_notifier = Arc::clone(&notifier);
-    let ns_scanner = Arc::clone(&scanner);
-    let ns_cfg = Arc::clone(&cfg);
-    let ns_stats = Arc::clone(&stats);
-    let ns_strategies = Arc::clone(&strategies);
-    let news_scan = tokio::spawn(async move {
-        if !ns_cfg.news_enabled {
-            tracing::info!("News cycle disabled (NEWS_ENABLED=false) — parked");
-            std::future::pending::<()>().await;
-            return;
-        }
+    // Spawn bet scanning loop (market scoring + betting, always on)
+    let bs_portfolio = Arc::clone(&portfolio);
+    let bs_notifier = Arc::clone(&notifier);
+    let bs_scanner = Arc::clone(&scanner);
+    let bs_cfg = Arc::clone(&cfg);
+    let bs_stats = Arc::clone(&stats);
+    let bs_strategies = Arc::clone(&strategies);
+    let bet_scan = tokio::spawn(async move {
         let mut seen_headlines: std::collections::HashSet<String> =
             std::collections::HashSet::new();
 
         loop {
             let scan_start = std::time::Instant::now();
-            if let Err(e) = cycles::news_scan_cycle(
-                &ns_portfolio,
-                &ns_notifier,
-                &ns_scanner,
-                &ns_cfg,
-                &ns_stats,
-                &ns_strategies,
+            if let Err(e) = cycles::bet_scan_cycle(
+                &bs_portfolio,
+                &bs_notifier,
+                &bs_scanner,
+                &bs_cfg,
+                &bs_stats,
+                &bs_strategies,
                 &mut seen_headlines,
             )
             .await
             {
-                tracing::error!(err = %e, "News scan cycle failed");
+                tracing::error!(err = %e, "Bet scan cycle failed");
             }
             metrics::record_duration("bot_scan_duration_seconds", scan_start.elapsed());
-            tokio::time::sleep(Duration::from_secs(ns_cfg.news_scan_interval_mins * 60)).await;
+            tokio::time::sleep(Duration::from_secs(bs_cfg.bet_scan_interval_mins * 60)).await;
         }
     });
 
@@ -542,8 +538,8 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
         r = housekeeping => {
             tracing::error!("Housekeeping loop exited: {:?}", r);
         }
-        r = news_scan => {
-            tracing::error!("News scan loop exited: {:?}", r);
+        r = bet_scan => {
+            tracing::error!("Bet scan loop exited: {:?}", r);
         }
         r = heartbeat => {
             tracing::error!("Heartbeat loop exited: {:?}", r);


### PR DESCRIPTION
Rename news_scan_cycle → bet_scan_cycle and remove the NEWS_ENABLED gate that blocked the entire scanning loop. The bet scan now always runs, scoring markets with the ML model and placing bets independently.

NEWS_ENABLED still controls whether news is fetched inside the scanner (saving RSS + embedding costs when disabled), it just no longer parks the whole cycle.

Add BET_SCAN_INTERVAL_MINS config (default 10) for independent control.