### PR TITLE
feat: /stats per-trader breakdown

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 tokio = { version = "1.50", features = ["full"] }
-reqwest = { version = "0.13.2", features = ["json"] }
+reqwest = { version = "0.13.2", features = ["json", "multipart"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -400,10 +400,10 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
     }
 
     let wr = win_rate(data.wins, data.losses);
-    let roi = if data.starting_bankroll > 0.0 {
-        data.pnl / data.starting_bankroll * 100.0
+    let roi_str = if data.starting_bankroll > 0.0 {
+        format!("`{:+.1}%`", data.pnl / data.starting_bankroll * 100.0)
     } else {
-        0.0
+        "—".to_string()
     };
 
     let unrealized_line = if data.open > 0 {
@@ -419,13 +419,13 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
         "📊 *Copy Trading Stats*\n\n\
          👥 Traders followed: {traders}\n\
          💰 Bankroll: `€{bankroll:.2}` (started: `€{starting:.2}`)\n\
-         💵 PnL: `€{pnl:+.2}` (ROI `{roi:+.1}%`)\n\
+         💵 PnL: `€{pnl:+.2}` (ROI {roi})\n\
          📋 Record: {wins}W/{losses}L ({wr:.0}%) | {open} open{unrealized}",
         traders = data.traders,
         bankroll = data.total_bankroll,
         starting = data.starting_bankroll,
         pnl = data.pnl,
-        roi = roi,
+        roi = roi_str,
         wins = data.wins,
         losses = data.losses,
         wr = wr,
@@ -904,13 +904,28 @@ mod tests {
 
     #[test]
     fn test_format_copy_stats_no_trader_rows_no_separator() {
-        let data = make_copy_stats_data(vec![]);
+        // traders > 0 but trader_rows empty — aggregate renders, no separator
+        let data = CopyStatsData {
+            traders: 2,
+            total_bankroll: 1000.0,
+            starting_bankroll: 800.0,
+            wins: 5,
+            losses: 2,
+            pnl: 200.0,
+            open: 0,
+            unrealized: 0.0,
+            exposure: 0.0,
+            trader_rows: vec![],
+        };
         let output = format_copy_stats(&data);
         assert!(
             !output.contains("━"),
             "separator should not appear with no trader rows"
         );
-        assert!(output.contains("No traders followed yet."));
+        assert!(
+            output.contains("Traders followed: 2"),
+            "aggregate header must appear"
+        );
     }
 
     #[test]

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -437,7 +437,7 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
         msg.push_str("\n\n━━━━━━━━━━━━━━━━━━");
         for t in &data.trader_rows {
             let roi_str = if t.starting_bankroll > 0.0 {
-                format!("{:+.1}%", t.pnl / t.starting_bankroll * 100.0)
+                format!("`{:+.1}%`", t.pnl / t.starting_bankroll * 100.0)
             } else {
                 "—".to_string()
             };

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -390,6 +390,7 @@ pub struct CopyStatsData {
     pub open: usize,
     pub unrealized: f64,
     pub exposure: f64,
+    pub trader_rows: Vec<TraderRow>,
 }
 
 /// Render the copy-trading `/stats` message.
@@ -414,7 +415,7 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
         String::new()
     };
 
-    format!(
+    let mut msg = format!(
         "📊 *Copy Trading Stats*\n\n\
          👥 Traders followed: {traders}\n\
          💰 Bankroll: `€{bankroll:.2}` (started: `€{starting:.2}`)\n\
@@ -430,7 +431,35 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
         wr = wr,
         open = data.open,
         unrealized = unrealized_line,
-    )
+    );
+
+    if !data.trader_rows.is_empty() {
+        msg.push_str("\n\n━━━━━━━━━━━━━━━━━━");
+        for t in &data.trader_rows {
+            let roi_str = if t.starting_bankroll > 0.0 {
+                format!("{:+.1}%", t.pnl / t.starting_bankroll * 100.0)
+            } else {
+                "—".to_string()
+            };
+            let open_str = if t.open > 0 {
+                format!("   {} open", t.open)
+            } else {
+                String::new()
+            };
+            msg.push_str(&format!(
+                "\n👤 *{name}*   `€{bankroll:.2}`   {wins}W/{losses}L   `€{pnl:+.2}` ({roi}){open}",
+                name = t.name,
+                bankroll = t.bankroll,
+                wins = t.wins,
+                losses = t.losses,
+                pnl = t.pnl,
+                roi = roi_str,
+                open = open_str,
+            ));
+        }
+    }
+
+    msg
 }
 
 /// A single followed-trader row for `/traders`.
@@ -832,5 +861,82 @@ mod tests {
             "expected per-strategy ROI in output: {output}"
         );
         assert!(output.contains("aggressive"));
+    }
+
+    fn make_trader_row(
+        name: &str,
+        bankroll: f64,
+        starting: f64,
+        wins: usize,
+        losses: usize,
+        pnl: f64,
+        open: usize,
+    ) -> TraderRow {
+        TraderRow {
+            name: name.to_string(),
+            wallet: format!("0x{name}wallet"),
+            wallet_short: format!("0x{name}"),
+            rank: None,
+            poly_pnl: None,
+            bankroll,
+            starting_bankroll: starting,
+            wins,
+            losses,
+            pnl,
+            open,
+        }
+    }
+
+    fn make_copy_stats_data(trader_rows: Vec<TraderRow>) -> CopyStatsData {
+        CopyStatsData {
+            traders: trader_rows.len(),
+            total_bankroll: 1000.0,
+            starting_bankroll: 800.0,
+            wins: 5,
+            losses: 2,
+            pnl: 200.0,
+            open: 1,
+            unrealized: 10.0,
+            exposure: 50.0,
+            trader_rows,
+        }
+    }
+
+    #[test]
+    fn test_format_copy_stats_no_trader_rows_no_separator() {
+        let data = make_copy_stats_data(vec![]);
+        let output = format_copy_stats(&data);
+        assert!(
+            !output.contains("━"),
+            "separator should not appear with no trader rows"
+        );
+        assert!(output.contains("No traders followed yet."));
+    }
+
+    #[test]
+    fn test_format_copy_stats_trader_rows_appear() {
+        let rows = vec![
+            make_trader_row("alice", 520.0, 400.0, 9, 3, 85.2, 2),
+            make_trader_row("bob", 430.0, 350.0, 6, 2, 95.1, 1),
+        ];
+        let data = make_copy_stats_data(rows);
+        let output = format_copy_stats(&data);
+        assert!(output.contains("━"), "separator must appear");
+        assert!(output.contains("alice"), "alice row must appear");
+        assert!(output.contains("bob"), "bob row must appear");
+        assert!(output.contains("9W/3L"), "alice record must appear");
+        assert!(output.contains("6W/2L"), "bob record must appear");
+    }
+
+    #[test]
+    fn test_format_copy_stats_trader_roi_zero_starting() {
+        let rows = vec![make_trader_row("ghost", 300.0, 0.0, 2, 1, 50.0, 0)];
+        let data = make_copy_stats_data(rows);
+        let output = format_copy_stats(&data);
+        // ROI should show "—" when starting_bankroll is 0
+        assert!(
+            output.contains("—"),
+            "ROI must be '—' when starting_bankroll is 0"
+        );
     }
 }

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -446,9 +446,15 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
             } else {
                 String::new()
             };
+            let safe_name = t
+                .name
+                .replace('_', "\\_")
+                .replace('*', "\\*")
+                .replace('[', "\\[")
+                .replace('`', "\\`");
             msg.push_str(&format!(
                 "\n👤 *{name}*   `€{bankroll:.2}`   {wins}W/{losses}L   `€{pnl:+.2}` ({roi}){open}",
-                name = t.name,
+                name = safe_name,
                 bankroll = t.bankroll,
                 wins = t.wins,
                 losses = t.losses,

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -441,6 +441,7 @@ pub struct TraderRow {
     pub rank: Option<i32>,
     pub poly_pnl: Option<f64>,
     pub bankroll: f64,
+    pub starting_bankroll: f64,
     pub wins: usize,
     pub losses: usize,
     pub pnl: f64,
@@ -535,6 +536,24 @@ pub fn format_copy_bet(n: &CopyBetNotif) -> String {
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    #[test]
+    fn test_trader_row_has_starting_bankroll() {
+        let row = TraderRow {
+            name: "alice".to_string(),
+            wallet: "0xabc".to_string(),
+            wallet_short: "0xabc123".to_string(),
+            rank: None,
+            poly_pnl: None,
+            bankroll: 500.0,
+            starting_bankroll: 400.0,
+            wins: 3,
+            losses: 1,
+            pnl: 100.0,
+            open: 2,
+        };
+        assert!((row.starting_bankroll - 400.0).abs() < 0.001);
+    }
 
     #[test]
     fn test_win_rate_zero() {

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -6,9 +6,12 @@ use crate::storage::portfolio::{Bet, BetSide};
 ///
 /// Prevents names from external APIs from breaking `parse_mode=Markdown` messages.
 pub fn escape_markdown(s: &str) -> String {
-    s.replace('_', "\\_")
+    // Escape `\` first so subsequent replacements don't double-escape.
+    s.replace('\\', "\\\\")
+        .replace('_', "\\_")
         .replace('*', "\\*")
         .replace('[', "\\[")
+        .replace(']', "\\]")
         .replace('`', "\\`")
 }
 
@@ -511,7 +514,7 @@ pub fn format_traders(traders: &[TraderRow]) -> String {
              \u{00a0}\u{00a0}💰 Bankroll: `€{bankroll:.2}`\n\
              \u{00a0}\u{00a0}📊 Record: {wins}W/{losses}L ({pnl:+.2}€)\n\
              \u{00a0}\u{00a0}🔓 Open: {open}",
-            name = t.name,
+            name = escape_markdown(&t.name),
             wallet = t.wallet,
             bankroll = t.bankroll,
             wins = t.wins,

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -2,6 +2,16 @@
 
 use crate::storage::portfolio::{Bet, BetSide};
 
+/// Escape Telegram legacy-Markdown special characters in user-supplied strings.
+///
+/// Prevents names from external APIs from breaking `parse_mode=Markdown` messages.
+pub fn escape_markdown(s: &str) -> String {
+    s.replace('_', "\\_")
+        .replace('*', "\\*")
+        .replace('[', "\\[")
+        .replace('`', "\\`")
+}
+
 /// Get emoji label for a strategy name.
 pub fn strategy_label(name: &str) -> &'static str {
     match name {
@@ -446,12 +456,7 @@ pub fn format_copy_stats(data: &CopyStatsData) -> String {
             } else {
                 String::new()
             };
-            let safe_name = t
-                .name
-                .replace('_', "\\_")
-                .replace('*', "\\*")
-                .replace('[', "\\[")
-                .replace('`', "\\`");
+            let safe_name = escape_markdown(&t.name);
             msg.push_str(&format!(
                 "\n👤 *{name}*   `€{bankroll:.2}`   {wins}W/{losses}L   `€{pnl:+.2}` ({roi}){open}",
                 name = safe_name,

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -209,6 +209,7 @@ impl PgPortfolio {
             open: open_count,
             unrealized,
             exposure,
+            trader_rows: vec![], // populated in Task 4 via collect_trader_rows
         };
 
         Ok(crate::format::format_copy_stats(&data))

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -174,7 +174,9 @@ impl PgPortfolio {
     /// so callers can reuse the already-fetched data without a second DB round-trip.
     async fn collect_trader_rows(&self) -> Result<(Vec<crate::format::TraderRow>, Vec<Bet>)> {
         let traders = self.get_active_traders().await?;
-        let open_bets = self.open_bets().await?;
+        // Best-effort: open-bet fetch failures show 0 open bets rather than
+        // failing the whole command (matches pre-refactor `/traders` behaviour).
+        let open_bets = self.open_bets().await.unwrap_or_default();
         // Precompute open-bet counts per strategy in one pass (O(open_bets)).
         let open_by_strat: HashMap<&str, usize> =
             open_bets.iter().fold(HashMap::new(), |mut acc, b| {

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -4,6 +4,8 @@
 //! Private postgres internals (`pool`, `FollowedTraderRow`) are exposed via
 //! `pub(super)` so this module can access them without a full visibility bump.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 
 use super::portfolio::Bet;
@@ -173,6 +175,12 @@ impl PgPortfolio {
     async fn collect_trader_rows(&self) -> Result<(Vec<crate::format::TraderRow>, Vec<Bet>)> {
         let traders = self.get_active_traders().await?;
         let open_bets = self.open_bets().await?;
+        // Precompute open-bet counts per strategy in one pass (O(open_bets)).
+        let open_by_strat: HashMap<&str, usize> =
+            open_bets.iter().fold(HashMap::new(), |mut acc, b| {
+                *acc.entry(b.strategy.as_str()).or_insert(0) += 1;
+                acc
+            });
         let mut rows = Vec::with_capacity(traders.len());
         for t in &traders {
             let short = &t.proxy_wallet[..8.min(t.proxy_wallet.len())];
@@ -181,7 +189,7 @@ impl PgPortfolio {
             let bankroll = self.strategy_bankroll(&strat).await.unwrap_or(0.0);
             let starting_bankroll = self.strategy_starting_bankroll(&strat).await.unwrap_or(0.0);
             let (wins, losses, pnl) = self.copy_trader_record(&strat).await.unwrap_or((0, 0, 0.0));
-            let open_count = open_bets.iter().filter(|b| b.strategy == strat).count();
+            let open_count = open_by_strat.get(strat.as_str()).copied().unwrap_or(0);
             rows.push(crate::format::TraderRow {
                 name,
                 wallet: t.proxy_wallet.clone(),

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -165,28 +165,47 @@ impl PgPortfolio {
         Ok((wins, losses, pnl))
     }
 
-    /// Build aggregate copy-trading stats for the /stats command.
-    pub async fn stats_summary_copy(&self) -> Result<String> {
+    /// Fetch per-trader stats rows for all active traders.
+    async fn collect_trader_rows(&self) -> Result<Vec<crate::format::TraderRow>> {
         let traders = self.get_active_traders().await?;
-        let open_bets = self.open_bets().await?;
-
-        let mut total_bankroll = 0.0_f64;
-        let mut total_starting = 0.0_f64;
-        let mut total_wins = 0_usize;
-        let mut total_losses = 0_usize;
-        let mut total_pnl = 0.0_f64;
-
+        let open_bets = self.open_bets().await.unwrap_or_default();
+        let mut rows = Vec::with_capacity(traders.len());
         for t in &traders {
             let short = &t.proxy_wallet[..8.min(t.proxy_wallet.len())];
+            let name = t.username.as_deref().unwrap_or(short).to_string();
             let strat = format!("copy:{short}");
-            total_bankroll += self.strategy_bankroll(&strat).await.unwrap_or(0.0);
-            total_starting += self.strategy_starting_bankroll(&strat).await.unwrap_or(0.0);
-            let (w, l, p) = self.copy_trader_record(&strat).await.unwrap_or((0, 0, 0.0));
-            total_wins += w;
-            total_losses += l;
-            total_pnl += p;
+            let bankroll = self.strategy_bankroll(&strat).await.unwrap_or(0.0);
+            let starting_bankroll = self.strategy_starting_bankroll(&strat).await.unwrap_or(0.0);
+            let (wins, losses, pnl) = self.copy_trader_record(&strat).await.unwrap_or((0, 0, 0.0));
+            let open_count = open_bets.iter().filter(|b| b.strategy == strat).count();
+            rows.push(crate::format::TraderRow {
+                name,
+                wallet: t.proxy_wallet.clone(),
+                wallet_short: short.to_string(),
+                rank: t.rank,
+                poly_pnl: t.pnl,
+                bankroll,
+                starting_bankroll,
+                wins,
+                losses,
+                pnl,
+                open: open_count,
+            });
         }
+        Ok(rows)
+    }
 
+    /// Build aggregate copy-trading stats for the /stats command.
+    pub async fn stats_summary_copy(&self) -> Result<String> {
+        let trader_rows = self.collect_trader_rows().await?;
+
+        let total_bankroll: f64 = trader_rows.iter().map(|r| r.bankroll).sum();
+        let total_starting: f64 = trader_rows.iter().map(|r| r.starting_bankroll).sum();
+        let total_wins: usize = trader_rows.iter().map(|r| r.wins).sum();
+        let total_losses: usize = trader_rows.iter().map(|r| r.losses).sum();
+        let total_pnl: f64 = trader_rows.iter().map(|r| r.pnl).sum();
+
+        let open_bets = self.open_bets().await?;
         let open_count = open_bets
             .iter()
             .filter(|b| b.strategy.starts_with("copy:"))
@@ -200,7 +219,7 @@ impl PgPortfolio {
         };
 
         let data = crate::format::CopyStatsData {
-            traders: traders.len(),
+            traders: trader_rows.len(),
             total_bankroll,
             starting_bankroll: total_starting,
             wins: total_wins,
@@ -209,7 +228,7 @@ impl PgPortfolio {
             open: open_count,
             unrealized,
             exposure,
-            trader_rows: vec![], // populated in Task 4 via collect_trader_rows
+            trader_rows,
         };
 
         Ok(crate::format::format_copy_stats(&data))
@@ -217,38 +236,7 @@ impl PgPortfolio {
 
     /// Build a summary of followed traders for the /traders command.
     pub async fn traders_summary(&self) -> Result<String> {
-        let traders = self.get_active_traders().await?;
-
-        let mut rows = Vec::with_capacity(traders.len());
-        for t in &traders {
-            let short = &t.proxy_wallet[..8.min(t.proxy_wallet.len())];
-            let name = t.username.as_deref().unwrap_or(short).to_string();
-            let strat = format!("copy:{short}");
-            let bankroll = self.strategy_bankroll(&strat).await.unwrap_or(0.0);
-            let (wins, losses, pnl) = self.copy_trader_record(&strat).await.unwrap_or((0, 0, 0.0));
-            let open_count = self
-                .open_bets()
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|b| b.strategy == strat)
-                .count();
-
-            rows.push(crate::format::TraderRow {
-                name,
-                wallet: t.proxy_wallet.clone(),
-                wallet_short: short.to_string(),
-                rank: t.rank,
-                poly_pnl: t.pnl,
-                bankroll,
-                starting_bankroll: 0.0,
-                wins,
-                losses,
-                pnl,
-                open: open_count,
-            });
-        }
-
+        let rows = self.collect_trader_rows().await?;
         Ok(crate::format::format_traders(&rows))
     }
 }

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -168,8 +168,8 @@ impl PgPortfolio {
 
     /// Fetch per-trader stats rows for all active traders.
     ///
-    /// Returns the rendered rows alongside the raw open bets so callers can
-    /// reuse the already-fetched data without a second DB round-trip.
+    /// Returns the structured [`TraderRow`] values alongside the raw open bets
+    /// so callers can reuse the already-fetched data without a second DB round-trip.
     async fn collect_trader_rows(&self) -> Result<(Vec<crate::format::TraderRow>, Vec<Bet>)> {
         let traders = self.get_active_traders().await?;
         let open_bets = self.open_bets().await?;

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -240,6 +240,7 @@ impl PgPortfolio {
                 rank: t.rank,
                 poly_pnl: t.pnl,
                 bankroll,
+                starting_bankroll: 0.0,
                 wins,
                 losses,
                 pnl,

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 
+use super::portfolio::Bet;
 use super::postgres::{FollowedTrader, FollowedTraderRow, NewCopyTradeEvent, PgPortfolio};
 
 impl PgPortfolio {
@@ -166,9 +167,12 @@ impl PgPortfolio {
     }
 
     /// Fetch per-trader stats rows for all active traders.
-    async fn collect_trader_rows(&self) -> Result<Vec<crate::format::TraderRow>> {
+    ///
+    /// Returns the rendered rows alongside the raw open bets so callers can
+    /// reuse the already-fetched data without a second DB round-trip.
+    async fn collect_trader_rows(&self) -> Result<(Vec<crate::format::TraderRow>, Vec<Bet>)> {
         let traders = self.get_active_traders().await?;
-        let open_bets = self.open_bets().await.unwrap_or_default();
+        let open_bets = self.open_bets().await?;
         let mut rows = Vec::with_capacity(traders.len());
         for t in &traders {
             let short = &t.proxy_wallet[..8.min(t.proxy_wallet.len())];
@@ -192,12 +196,12 @@ impl PgPortfolio {
                 open: open_count,
             });
         }
-        Ok(rows)
+        Ok((rows, open_bets))
     }
 
     /// Build aggregate copy-trading stats for the /stats command.
     pub async fn stats_summary_copy(&self) -> Result<String> {
-        let trader_rows = self.collect_trader_rows().await?;
+        let (trader_rows, open_bets) = self.collect_trader_rows().await?;
 
         let total_bankroll: f64 = trader_rows.iter().map(|r| r.bankroll).sum();
         let total_starting: f64 = trader_rows.iter().map(|r| r.starting_bankroll).sum();
@@ -205,7 +209,6 @@ impl PgPortfolio {
         let total_losses: usize = trader_rows.iter().map(|r| r.losses).sum();
         let total_pnl: f64 = trader_rows.iter().map(|r| r.pnl).sum();
 
-        let open_bets = self.open_bets().await?;
         let open_count = open_bets
             .iter()
             .filter(|b| b.strategy.starts_with("copy:"))
@@ -236,7 +239,7 @@ impl PgPortfolio {
 
     /// Build a summary of followed traders for the /traders command.
     pub async fn traders_summary(&self) -> Result<String> {
-        let rows = self.collect_trader_rows().await?;
+        let (rows, _) = self.collect_trader_rows().await?;
         Ok(crate::format::format_traders(&rows))
     }
 }

--- a/copy-trading-bot/src/telegram/commands.rs
+++ b/copy-trading-bot/src/telegram/commands.rs
@@ -103,6 +103,15 @@ pub async fn handle_command(
                     {
                         tracing::warn!(err = %e, "Failed to init copy trader bankroll");
                     }
+                    if let Err(e) = portfolio
+                        .ensure_key(
+                            &format!("starting_bankroll:{strat_key}"),
+                            COPY_TRADER_STARTING_BANKROLL,
+                        )
+                        .await
+                    {
+                        tracing::warn!(err = %e, "Failed to init copy trader starting bankroll");
+                    }
                     let username = fetch_trader_username(http, &wallet).await;
                     let display = username.as_deref().unwrap_or(short);
                     match portfolio


### PR DESCRIPTION
## Summary

- Extend \`/stats\` to show compact per-trader rows below aggregate summary: name | bankroll | W/L | PnL | ROI% | open
- Extract \`collect_trader_rows()\` helper eliminating duplicate DB loop shared between \`stats_summary_copy\` and \`traders_summary\` (also fixes N calls to \`open_bets()\` → 1)
- Add \`starting_bankroll\` to \`TraderRow\` for per-trader ROI calculation
- Fix pre-existing compile error: \`reqwest multipart\` feature missing from \`common/Cargo.toml\`

## Test Plan

- [x] 29 unit tests pass (\`cargo test -p polymarket-common --lib -- format\`)
- [x] All 3 crates build clean (\`cargo build\`)
- [ ] \`/stats\` in Telegram shows aggregate block + per-trader rows with separator
- [ ] \`/traders\` output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)