### PR TITLE
fix(ml): pin scikit-learn==1.8.0 to match pickled model

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,9 @@
 xgboost>=3.2.0
 lightgbm>=4.6.0
-scikit-learn>=1.9.0
+# Pinned: model artifact (ensemble.joblib) is pickled with sklearn 1.8.0.
+# 1.9.0 moved the internal `_loss` module -> unpickle fails (ModuleNotFoundError: No module named '_loss').
+# Bump only together with a model retrain on the new version.
+scikit-learn==1.8.0
 pandas>=3.0.3
 numpy>=2.4.6
 requests>=2.34.2


### PR DESCRIPTION
## Problem

`model-server` crash-looped on prod after the dependabot bump `scikit-learn>=1.8.0`→`>=1.9.0` (commit 24550a3). Deploy rebuilds the image from `scripts/requirements.txt`, installing 1.9.0. The `/model/ensemble.joblib` artifact is pickled with **1.8.0**; sklearn 1.9.0 renamed the internal `_loss` module, so unpickling failed:

```
ModuleNotFoundError: No module named '_loss'
```

Confirmed on host: pickle version string `1.8.0`, runtime `1.9.0`.

## Fix

Pin `scikit-learn==1.8.0` to match the artifact. Prod already hotfixed; this makes it survive the next deploy (rsync `--delete` would otherwise wipe the host edit).

## Note

A `>=` constraint on a pickled-model dep is the root flaw. To move to a newer sklearn later: bump the dep **and** regenerate `ensemble.joblib` on that version in the same change (run `train_model.py` headless before the server loads it).