### PR TITLE
refactor(config): migrate CrawlerConfig and BacktestConfig to confique

### DIFF
--- a/common/src/data/crawler.rs
+++ b/common/src/data/crawler.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use confique::{Config, Layer};
 use reqwest::Client;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -9,25 +10,26 @@ const GAMMA_API: &str = "https://gamma-api.polymarket.com";
 const CLOB_API: &str = "https://clob.polymarket.com";
 const PAGE_SIZE: usize = 100;
 
+#[derive(Config)]
 pub struct CrawlerConfig {
+    #[config(default = 100)]
     pub rate_limit_ms: u64,
+    #[config(default = 2000)]
     pub market_limit: usize,
+    #[config(default = true)]
     pub crypto_only: bool,
+    #[config(default = 1000.0)]
     pub min_volume: f64,
+    #[config(default = 20)]
     pub min_ticks: usize,
+    #[config(default = 4.0)]
     pub min_duration_hours: f64,
 }
 
 impl Default for CrawlerConfig {
     fn default() -> Self {
-        Self {
-            rate_limit_ms: 100,
-            market_limit: 2000,
-            crypto_only: true,
-            min_volume: 1000.0,
-            min_ticks: 20,
-            min_duration_hours: 4.0,
-        }
+        Self::from_layer(<Self as Config>::Layer::default_values())
+            .expect("all fields have confique defaults")
     }
 }
 

--- a/trading-bot/src/backtest/engine.rs
+++ b/trading-bot/src/backtest/engine.rs
@@ -1,35 +1,38 @@
 use std::collections::HashMap;
 
+use confique::{Config, Layer};
+
 use super::metrics::BacktestMetrics;
 use super::portfolio::{Portfolio, Side};
 use crate::data::models::{HistoricalMarket, PriceTick};
 
+#[derive(Config)]
 pub struct BacktestConfig {
+    #[config(env = "BACKTEST_STARTING_CASH", default = 10_000.0)]
     pub starting_cash: f64,
+    #[config(env = "BACKTEST_EDGE_THRESHOLD", default = 0.03)]
     pub edge_threshold: f64,
+    #[config(env = "BACKTEST_POSITION_SIZE_PCT", default = 0.05)]
     pub position_size_pct: f64,
     /// Slippage as a fraction of price (e.g., 0.01 = 1%)
+    #[config(env = "BACKTEST_SLIPPAGE_PCT", default = 0.01)]
     pub slippage_pct: f64,
     /// Trading fee as a fraction of notional (e.g., 0.02 = 2%)
+    #[config(env = "BACKTEST_FEE_PCT", default = 0.02)]
     pub fee_pct: f64,
     /// How far into the history to enter (fraction 0.0-1.0).
     /// 0.2 means enter after observing the first 20% of ticks.
+    #[config(env = "BACKTEST_ENTRY_POINT", default = 0.2)]
     pub entry_point: f64,
     /// Minimum observed ticks before entry (overrides entry_point if too few).
+    #[config(env = "BACKTEST_MIN_LOOKBACK", default = 10)]
     pub min_lookback: usize,
 }
 
 impl Default for BacktestConfig {
     fn default() -> Self {
-        Self {
-            starting_cash: 10_000.0,
-            edge_threshold: 0.03,
-            position_size_pct: 0.05,
-            slippage_pct: 0.01,
-            fee_pct: 0.02,
-            entry_point: 0.2,
-            min_lookback: 10,
-        }
+        Self::from_layer(<Self as Config>::Layer::default_values())
+            .expect("all fields have confique defaults")
     }
 }
 


### PR DESCRIPTION
## What

Migrates the two remaining hand-rolled config structs to confique, matching the pattern already used by `AppConfig` and `CopyTradingConfig`.

- **`CrawlerConfig`** (`common/src/data/crawler.rs`) — `#[derive(Config)]` with `#[config(default = ...)]` on every field. Manual `Default` impl now reads those defaults via `from_layer(Layer::default_values())` instead of a duplicated literal.
- **`BacktestConfig`** (`trading-bot/src/backtest/engine.rs`) — same migration, plus `#[config(env = "BACKTEST_*")]` on all fields so backtests can be tuned via environment variables when loaded through the builder.

## Why

Single source of truth for defaults — the values live only in the `#[config(default)]` attributes, so there's no manual `Default` body to drift out of sync.

## Notes

- Callers are unchanged: `backtest_runner.rs` still constructs both configs via struct literals, so behavior is identical today. The `BACKTEST_*` env plumbing is present but dormant until the runner switches to `BacktestConfig::builder().env().load()`.

## Testing

- `cargo build --workspace` clean
- `cargo test --workspace` — 105 passed, 0 failed