### PR TITLE
chore: rename ghcr images to polymarket-trading-bot / polymarket-copy-trading-bot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ on:
 
 env:
   DEPLOY_DIR: /opt/polymarket-bot
-  IMAGE: ghcr.io/skharchikov/polymarket-bot:latest
-  IMAGE_COPY: ghcr.io/skharchikov/polymarket-bot-copy:latest
+  IMAGE: ghcr.io/skharchikov/polymarket-trading-bot:latest
+  IMAGE_COPY: ghcr.io/skharchikov/polymarket-copy-trading-bot:latest
 
 jobs:
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,8 @@ jobs:
           file: trading-bot/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ needs.release.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/polymarket-trading-bot:latest
+            ghcr.io/${{ github.repository_owner }}/polymarket-trading-bot:${{ needs.release.outputs.tag }}
 
       - name: Build and push copy-trading-bot
         uses: docker/build-push-action@v7
@@ -116,13 +116,13 @@ jobs:
           file: copy-trading-bot/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}-copy:latest
-            ghcr.io/${{ github.repository }}-copy:${{ needs.release.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/polymarket-copy-trading-bot:latest
+            ghcr.io/${{ github.repository_owner }}/polymarket-copy-trading-bot:${{ needs.release.outputs.tag }}
 
       - name: Prune old images (keep last 3)
         uses: actions/delete-package-versions@v5
         with:
-          package-name: polymarket-bot
+          package-name: polymarket-trading-bot
           package-type: container
           min-versions-to-keep: 3
           delete-untagged-versions: true
@@ -130,7 +130,7 @@ jobs:
       - name: Prune old copy-trading-bot images (keep last 3)
         uses: actions/delete-package-versions@v5
         with:
-          package-name: polymarket-bot-copy
+          package-name: polymarket-copy-trading-bot
           package-type: container
           min-versions-to-keep: 3
           delete-untagged-versions: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     restart: unless-stopped
 
   bot:
-    image: ghcr.io/skharchikov/polymarket-bot:latest
+    image: ghcr.io/skharchikov/polymarket-trading-bot:latest
     depends_on:
       postgres:
         condition: service_healthy
@@ -57,7 +57,7 @@ services:
     restart: unless-stopped
 
   copy-trading-bot:
-    image: ghcr.io/skharchikov/polymarket-bot-copy:latest
+    image: ghcr.io/skharchikov/polymarket-copy-trading-bot:latest
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What

Rename published GHCR images:
- `polymarket-bot` → `polymarket-trading-bot`
- `polymarket-bot-copy` → `polymarket-copy-trading-bot`

## Changes
- `release.yml`: build/push tags + prune `package-name` (switched `github.repository` → `github.repository_owner` + explicit name)
- `deploy.yml`: `IMAGE` / `IMAGE_COPY`
- `docker-compose.yml`: both `image:` lines

## Notes
- Next release publishes **new** packages; old `polymarket-bot` / `polymarket-bot-copy` remain in GHCR until deleted manually.
- New packages default **private** — set visibility public or ensure deploy host auth, else first `docker pull` fails.
- `DEPLOY_DIR: /opt/polymarket-bot` left unchanged (filesystem path, not image).