### PR TITLE
feat(copy-trading): show followed-trader stats from Polymarket

### DIFF
--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -84,6 +84,37 @@ impl PgPortfolio {
         Ok(())
     }
 
+    /// Refresh leaderboard stats (rank, pnl, volume, username) for a trader.
+    ///
+    /// Unlike [`add_followed_trader`](Self::add_followed_trader) this does not
+    /// touch `source` or `active`, so a deactivated trader stays deactivated.
+    pub async fn update_trader_stats(
+        &self,
+        wallet: &str,
+        rank: Option<i32>,
+        pnl: Option<f64>,
+        volume: Option<f64>,
+        username: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE followed_traders SET \
+               rank     = $1, \
+               pnl      = $2, \
+               volume   = $3, \
+               username = COALESCE($4, username) \
+             WHERE proxy_wallet = $5",
+        )
+        .bind(rank)
+        .bind(pnl)
+        .bind(volume)
+        .bind(username)
+        .bind(wallet)
+        .execute(&self.pool)
+        .await
+        .context("update_trader_stats")?;
+        Ok(())
+    }
+
     /// Set the `username` field for a trader (backfill / refresh).
     pub async fn update_trader_username(&self, wallet: &str, username: &str) -> Result<()> {
         sqlx::query("UPDATE followed_traders SET username = $1 WHERE proxy_wallet = $2")

--- a/copy-trading-bot/src/scanner/copy_trader.rs
+++ b/copy-trading-bot/src/scanner/copy_trader.rs
@@ -35,6 +35,8 @@ struct LeaderboardEntry {
     #[serde(rename = "userName")]
     name: Option<String>,
     #[serde(default)]
+    rank: Option<serde_json::Value>,
+    #[serde(default)]
     pnl: Option<serde_json::Value>,
     #[serde(default, rename = "vol")]
     volume: Option<serde_json::Value>,
@@ -47,6 +49,15 @@ impl LeaderboardEntry {
 
     fn volume_f64(&self) -> f64 {
         self.volume_like(&self.volume)
+    }
+
+    /// Rank arrives as a string (e.g. `"80"`) — parse to i32, `None` if absent.
+    fn rank_i32(&self) -> Option<i32> {
+        self.rank.as_ref().and_then(|v| match v {
+            serde_json::Value::Number(n) => n.as_i64().map(|n| n as i32),
+            serde_json::Value::String(s) => s.parse().ok(),
+            _ => None,
+        })
     }
 
     fn volume_like(&self, v: &Option<serde_json::Value>) -> f64 {
@@ -119,6 +130,92 @@ pub struct LeaderboardDisplay {
 // ---------------------------------------------------------------------------
 // Standalone leaderboard helpers (no monitor instance required)
 // ---------------------------------------------------------------------------
+
+/// Per-wallet stats from the Polymarket leaderboard endpoint.
+#[derive(Debug, Clone)]
+pub struct TraderStats {
+    pub rank: Option<i32>,
+    pub pnl: f64,
+    pub volume: f64,
+    pub username: Option<String>,
+}
+
+/// Extract [`TraderStats`] from a per-wallet leaderboard response.
+/// Returns `None` when the wallet has no leaderboard entry.
+fn parse_trader_stats(entries: Vec<LeaderboardEntry>) -> Option<TraderStats> {
+    let e = entries.into_iter().next()?;
+    Some(TraderStats {
+        rank: e.rank_i32(),
+        pnl: e.pnl_f64(),
+        volume: e.volume_f64(),
+        username: e.name.filter(|n| !n.is_empty()),
+    })
+}
+
+/// Fetch all-time stats (rank, PnL, volume, username) for a single wallet via
+/// `GET /v1/leaderboard?timePeriod=ALL&limit=1&user=<wallet>`.
+///
+/// Returns `Ok(None)` when the wallet has no leaderboard entry.
+pub async fn fetch_trader_stats(http: &Client, wallet: &str) -> Result<Option<TraderStats>> {
+    let url = format!("{DATA_API}/v1/leaderboard?timePeriod=ALL&limit=1&user={wallet}");
+    let entries: Vec<LeaderboardEntry> = http
+        .get(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .context("trader stats request failed")?
+        .error_for_status()
+        .context("trader stats returned non-2xx")?
+        .json()
+        .await
+        .context("trader stats JSON parse failed")?;
+    Ok(parse_trader_stats(entries))
+}
+
+/// Refresh leaderboard stats for all active followed traders (best-effort).
+///
+/// Fetches per-wallet stats concurrently and writes them back to
+/// `followed_traders`. Failures are logged and skipped so a partial refresh
+/// never blocks the caller.
+pub async fn refresh_followed_trader_stats(http: &Client, portfolio: &PgPortfolio) {
+    let traders = match portfolio.get_active_traders().await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(err = %e, "Failed to load traders for stats refresh");
+            return;
+        }
+    };
+
+    let fetches = traders.iter().map(|t| async move {
+        let res = fetch_trader_stats(http, &t.proxy_wallet).await;
+        (t, res)
+    });
+
+    for (trader, res) in join_all(fetches).await {
+        match res {
+            Ok(Some(stats)) => {
+                if let Err(e) = portfolio
+                    .update_trader_stats(
+                        &trader.proxy_wallet,
+                        stats.rank,
+                        Some(stats.pnl),
+                        Some(stats.volume),
+                        stats.username.as_deref(),
+                    )
+                    .await
+                {
+                    tracing::warn!(wallet = %trader.proxy_wallet, err = %e, "Failed to save trader stats");
+                }
+            }
+            Ok(None) => {
+                tracing::debug!(wallet = %trader.proxy_wallet, "No leaderboard entry for trader");
+            }
+            Err(e) => {
+                tracing::warn!(wallet = %trader.proxy_wallet, err = %e, "Failed to fetch trader stats");
+            }
+        }
+    }
+}
 
 /// Fetch a trader's display name via the activity endpoint.
 /// Returns `None` if the request fails or the trader has no activity.
@@ -618,6 +715,51 @@ mod tests {
         assert_eq!(trades[0].size_usd, 0.0);
     }
 
+    // Real API response shape captured 2026-07-15 from
+    // GET /v1/leaderboard?timePeriod=ALL&limit=1&user=<wallet>
+    const TRADER_STATS_JSON: &str = r#"[
+        {
+            "rank": "80",
+            "proxyWallet": "0x37c1874a60d348903594a96703e0507c518fc53a",
+            "userName": "CemeterySun",
+            "xUsername": "",
+            "verifiedBadge": false,
+            "vol": 148559637.69049004,
+            "pnl": 1927132.677116769,
+            "profileImage": ""
+        }
+    ]"#;
+
+    #[test]
+    fn test_parse_trader_stats_real_shape() {
+        let entries: Vec<LeaderboardEntry> = serde_json::from_str(TRADER_STATS_JSON).unwrap();
+        let stats = parse_trader_stats(entries).expect("stats should parse");
+        // rank arrives as a string — must be parsed to i32
+        assert_eq!(stats.rank, Some(80));
+        assert!((stats.pnl - 1_927_132.677_116_769).abs() < 1e-6);
+        assert!((stats.volume - 148_559_637.690_490_04).abs() < 1e-6);
+        assert_eq!(stats.username.as_deref(), Some("CemeterySun"));
+    }
+
+    #[test]
+    fn test_parse_trader_stats_empty_response() {
+        // Wallet with no leaderboard entry → empty array → None
+        let entries: Vec<LeaderboardEntry> = serde_json::from_str("[]").unwrap();
+        assert!(parse_trader_stats(entries).is_none());
+    }
+
+    #[test]
+    fn test_parse_trader_stats_missing_optional_fields() {
+        // rank absent, empty username → still returns pnl/vol, rank None, username None
+        let json = r#"[{"proxyWallet": "0xabc", "userName": "", "pnl": 100.5, "vol": 200.0}]"#;
+        let entries: Vec<LeaderboardEntry> = serde_json::from_str(json).unwrap();
+        let stats = parse_trader_stats(entries).expect("stats should parse");
+        assert_eq!(stats.rank, None);
+        assert_eq!(stats.pnl, 100.5);
+        assert_eq!(stats.volume, 200.0);
+        assert_eq!(stats.username, None);
+    }
+
     #[tokio::test]
     #[ignore] // hits real API
     async fn test_fetch_leaderboard_live() {
@@ -632,6 +774,21 @@ mod tests {
             "{}",
             format_multi_leaderboard(&[("All Time", entries.as_slice())])
         );
+    }
+
+    #[tokio::test]
+    #[ignore] // hits real API
+    async fn test_fetch_trader_stats_live() {
+        let http = Client::new();
+        let wallet = "0x37c1874a60d348903594a96703e0507c518fc53a";
+        let stats = fetch_trader_stats(&http, wallet)
+            .await
+            .unwrap()
+            .expect("known trader should have stats");
+        assert!(stats.pnl != 0.0, "pnl should be non-zero");
+        assert!(stats.volume > 0.0, "volume should be positive");
+        assert!(stats.rank.is_some(), "rank should be present");
+        println!("{stats:?}");
     }
 
     #[tokio::test]

--- a/copy-trading-bot/src/telegram/commands.rs
+++ b/copy-trading-bot/src/telegram/commands.rs
@@ -3,7 +3,8 @@
 use crate::config::CopyTradingConfig;
 use crate::cycles::copy_trade::COPY_TRADER_STARTING_BANKROLL;
 use crate::scanner::copy_trader::{
-    CopyTraderMonitor, fetch_leaderboard, fetch_trader_username, format_multi_leaderboard,
+    CopyTraderMonitor, fetch_leaderboard, fetch_trader_stats, fetch_trader_username,
+    format_multi_leaderboard, refresh_followed_trader_stats,
 };
 use crate::storage::postgres::PgPortfolio;
 use crate::telegram::notifier::TelegramNotifier;
@@ -50,13 +51,17 @@ pub async fn handle_command(
                 "⚠️ Failed to load copy positions".to_string()
             }
         },
-        "traders" => match portfolio.traders_summary().await {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::warn!(err = %e, "Failed to build traders summary");
-                "⚠️ Failed to load traders".to_string()
+        "traders" => {
+            // Pull fresh leaderboard stats (rank / Poly PnL) before rendering.
+            refresh_followed_trader_stats(http, portfolio).await;
+            match portfolio.traders_summary().await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(err = %e, "Failed to build traders summary");
+                    "⚠️ Failed to load traders".to_string()
+                }
             }
-        },
+        }
         "leaderboard" => {
             let (day_res, month_res, all_res) = tokio::join!(
                 fetch_leaderboard(http, "DAY"),
@@ -112,16 +117,24 @@ pub async fn handle_command(
                     {
                         tracing::warn!(err = %e, "Failed to init copy trader starting bankroll");
                     }
-                    let username = fetch_trader_username(http, &wallet).await;
+                    let stats = fetch_trader_stats(http, &wallet).await.ok().flatten();
+                    let mut username = stats.as_ref().and_then(|s| s.username.clone());
+                    if username.is_none() {
+                        username = fetch_trader_username(http, &wallet).await;
+                    }
                     let display = username.as_deref().unwrap_or(short);
+                    let (rank, pnl, volume) = stats
+                        .as_ref()
+                        .map(|s| (s.rank, Some(s.pnl), Some(s.volume)))
+                        .unwrap_or((None, None, None));
                     match portfolio
                         .add_followed_trader(
                             &wallet,
                             username.as_deref(),
                             "manual",
-                            None,
-                            None,
-                            None,
+                            rank,
+                            pnl,
+                            volume,
                         )
                         .await
                     {


### PR DESCRIPTION
### Reason for changes
`/traders` always showed `Rank: — | Poly PnL: —` because trader stats were inserted as NULL on `/follow` and nothing ever backfilled them from Polymarket.

### Notable changes
- New `fetch_trader_stats()` using the Data API per-wallet leaderboard filter (`GET /v1/leaderboard?timePeriod=ALL&limit=1&user=<wallet>`) — returns rank (string in API, parsed to i32), PnL, volume, and username.
- `/follow` now stores real rank/pnl/volume/username at follow time, falling back to the activity endpoint for the username when the wallet has no leaderboard entry.
- `/traders` refreshes stats for all active traders (concurrent, best-effort) before rendering, so existing rows backfill on next use.
- New `update_trader_stats()` DB method that only touches stats columns — it never flips `source`/`active`, so unfollowed traders stay unfollowed.

### Testing
- 3 unit tests for parsing the captured real API response shape (string rank, empty response, missing optional fields).
- `#[ignore]` live-API test `test_fetch_trader_stats_live` verified against production data (`rank: 81, pnl: $1.9M, username: CemeterySun`).
- Full workspace test suite green; clippy clean.