### PR TITLE
fix(copy-trading): copy trader's actual YES/NO side instead of always YES

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -70,10 +70,8 @@ pub struct OpenBetView<'a> {
 impl<'a> OpenBetView<'a> {
     /// Current price on the bet's side.
     fn current_price(&self) -> Option<f64> {
-        self.current_yes_price.map(|p| match self.bet.side {
-            BetSide::Yes => p,
-            BetSide::No => 1.0 - p,
-        })
+        self.current_yes_price
+            .map(|p| self.bet.side.price_from_yes(p))
     }
 
     /// Unrealized PnL in EUR.

--- a/common/src/storage/portfolio.rs
+++ b/common/src/storage/portfolio.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum BetSide {
     Yes,
     No,
@@ -13,6 +13,54 @@ impl std::fmt::Display for BetSide {
             BetSide::Yes => write!(f, "YES"),
             BetSide::No => write!(f, "NO"),
         }
+    }
+}
+
+impl BetSide {
+    /// Map a Polymarket market outcome index to a bet side.
+    ///
+    /// Markets are binary: index 0 = YES token, index 1 = NO token. Any other
+    /// value comes from a multi-outcome market this bot does not support, so we
+    /// return `None` and let the caller skip it rather than silently coercing.
+    pub fn from_outcome_index(outcome_index: i64) -> Option<BetSide> {
+        match outcome_index {
+            0 => Some(BetSide::Yes),
+            1 => Some(BetSide::No),
+            _ => None,
+        }
+    }
+
+    /// Price of this side given the market's YES price.
+    ///
+    /// YES tokens trade at the YES price; NO tokens at its complement.
+    pub fn price_from_yes(&self, yes_price: f64) -> f64 {
+        match self {
+            BetSide::Yes => yes_price,
+            BetSide::No => 1.0 - yes_price,
+        }
+    }
+}
+
+#[cfg(test)]
+mod bet_side_tests {
+    use super::BetSide;
+
+    #[test]
+    fn from_outcome_index_maps_binary_outcomes() {
+        assert_eq!(BetSide::from_outcome_index(0), Some(BetSide::Yes));
+        assert_eq!(BetSide::from_outcome_index(1), Some(BetSide::No));
+    }
+
+    #[test]
+    fn from_outcome_index_rejects_multi_outcome() {
+        assert_eq!(BetSide::from_outcome_index(2), None);
+        assert_eq!(BetSide::from_outcome_index(-1), None);
+    }
+
+    #[test]
+    fn price_from_yes_uses_complement_for_no() {
+        assert_eq!(BetSide::Yes.price_from_yes(0.30), 0.30);
+        assert!((BetSide::No.price_from_yes(0.30) - 0.70).abs() < f64::EPSILON);
     }
 }
 

--- a/common/src/storage/postgres.rs
+++ b/common/src/storage/postgres.rs
@@ -472,7 +472,6 @@ impl PgPortfolio {
     /// Fetch live unrealized PnL and exposure, split into (ml, copy) tuples of (unrealized, exposure).
     pub(super) async fn live_unrealized(&self) -> ((f64, f64), (f64, f64)) {
         use crate::data::models::fetch_yes_prices;
-        use crate::storage::portfolio::BetSide;
 
         let open = match self.open_bets().await {
             Ok(b) => b,
@@ -506,10 +505,7 @@ impl PgPortfolio {
                 ml_exposure += bet.cost;
             }
             if let Some(yp) = yes_price {
-                let cur = match bet.side {
-                    BetSide::Yes => yp,
-                    BetSide::No => 1.0 - yp,
-                };
+                let cur = bet.side.price_from_yes(yp);
                 let pnl = bet.shares * cur - bet.cost;
                 if is_copy {
                     copy_unrealized += pnl;
@@ -1143,10 +1139,7 @@ impl PgPortfolio {
         };
 
         // Selling shares at current market price
-        let sell_price = match side {
-            BetSide::Yes => current_yes_price,
-            BetSide::No => 1.0 - current_yes_price,
-        };
+        let sell_price = side.price_from_yes(current_yes_price);
         let fee_pct = 0.02;
         let gross_payout = r.shares * sell_price;
         let exit_fee = gross_payout * fee_pct;

--- a/copy-trading-bot/src/cycles/copy_trade.rs
+++ b/copy-trading-bot/src/cycles/copy_trade.rs
@@ -172,6 +172,20 @@ pub async fn copy_trade_cycle(
             continue;
         }
 
+        // Mirror the trader's actual side. `trade.price` is quoted for whichever
+        // token they bought, so it is the correct entry price for our side.
+        // Multi-outcome markets (index > 1) are unsupported — skip them rather
+        // than betting the wrong side.
+        let Some(bet_side) = BetSide::from_outcome_index(trade.outcome_index) else {
+            tracing::warn!(
+                trader = wallet_short,
+                slug = %trade.slug,
+                outcome_index = trade.outcome_index,
+                "Copy-trade skip: unsupported multi-outcome market"
+            );
+            continue;
+        };
+
         // Fetch market data (resolves slug → Gamma numeric ID + events)
         let market = match fetch_market_by_slug(&http, &trade.slug).await {
             Ok(m) => m,
@@ -208,13 +222,17 @@ pub async fn copy_trade_cycle(
                 .next()
                 .flatten()
         };
-        if let Some(current) = current_yes_price {
-            let drift = (current - trade.price).abs();
+        if let Some(current_yes) = current_yes_price {
+            // Compare the trader's entry against the current price of the same
+            // side they bought.
+            let current_side_price = bet_side.price_from_yes(current_yes);
+            let drift = (current_side_price - trade.price).abs();
             if drift > MAX_PRICE_DRIFT {
                 tracing::info!(
                     market = %market.market_id,
+                    side = %bet_side,
                     trader_price = trade.price,
-                    current_price = current,
+                    current_price = current_side_price,
                     drift = drift,
                     "Copy-trade skip: price drifted too far"
                 );
@@ -301,15 +319,14 @@ pub async fn copy_trade_cycle(
 
         let edge = estimated_prob - entry_price;
         let reasoning = format!(
-            "Copy-trade: {} bought at {:.1}%",
-            trader_display,
+            "Copy-trade: {trader_display} bought {bet_side} at {:.1}%",
             entry_price * 100.0,
         );
 
         let new_bet = NewBet {
             market_id: market.market_id.clone(),
             question: market.question.clone(),
-            side: BetSide::Yes,
+            side: bet_side,
             entry_price,
             slipped_price,
             shares,

--- a/copy-trading-bot/src/scanner/copy_trader.rs
+++ b/copy-trading-bot/src/scanner/copy_trader.rs
@@ -80,6 +80,9 @@ struct ActivityEvent {
     condition_id: Option<String>,
     /// "BUY" | "SELL"
     side: Option<String>,
+    /// Which market outcome token was traded: 0 = YES (first token), 1 = NO.
+    #[serde(rename = "outcomeIndex")]
+    outcome_index: Option<i64>,
     price: Option<f64>,
     /// Actual USD value of the trade (not shares).
     #[serde(rename = "usdcSize")]
@@ -103,6 +106,9 @@ pub struct TraderTrade {
     pub condition_id: String,
     /// "BUY" or "SELL"
     pub side: String,
+    /// Which market outcome the trade is on: 0 = YES token, 1 = NO token.
+    /// Defaults to 0 when the API omits it.
+    pub outcome_index: i64,
     pub price: f64,
     /// Size in USD (usdcSize from API).
     pub size_usd: f64,
@@ -392,6 +398,7 @@ fn parse_activity_events(events: Vec<ActivityEvent>) -> Vec<TraderTrade> {
             let condition_id = e.condition_id?;
             let side = e.side?;
             let price = e.price?;
+            let outcome_index = e.outcome_index.unwrap_or(0);
             let size_usd = e.usdc_size.unwrap_or(0.0);
             let ts_secs = e.timestamp?;
             let timestamp = DateTime::from_timestamp(ts_secs, 0).unwrap_or_else(Utc::now);
@@ -399,6 +406,7 @@ fn parse_activity_events(events: Vec<ActivityEvent>) -> Vec<TraderTrade> {
                 slug,
                 condition_id,
                 side,
+                outcome_index,
                 price,
                 size_usd,
                 tx_hash: e.tx_hash,
@@ -662,11 +670,47 @@ mod tests {
             "0xfab8520004b4d201119f0362dc8678e8cf7f11b514efc48bc5a48aebf7974b50"
         );
         assert_eq!(t.side, "BUY");
+        assert_eq!(t.outcome_index, 0);
         assert_eq!(t.price, 0.49);
         // usdcSize, not size (shares)
         assert_eq!(t.size_usd, 9.604);
         assert_eq!(t.tx_hash.as_deref(), Some("0x36b6c841eb1"));
         assert_eq!(t.timestamp.timestamp(), 1773601939);
+    }
+
+    /// A trader buying the NO token (outcomeIndex 1) must be carried through so
+    /// the copy-bot mirrors the correct side instead of always betting YES.
+    #[test]
+    fn test_parse_activity_events_carries_no_outcome() {
+        let json = r#"[{
+            "slug": "some-market",
+            "conditionId": "0xabc",
+            "side": "BUY",
+            "price": 0.30,
+            "usdcSize": 15.0,
+            "outcomeIndex": 1,
+            "timestamp": 1000
+        }]"#;
+        let events: Vec<ActivityEvent> = serde_json::from_str(json).unwrap();
+        let trades = parse_activity_events(events);
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].outcome_index, 1, "NO trade must be preserved");
+    }
+
+    /// When the API omits outcomeIndex, default to 0 (YES).
+    #[test]
+    fn test_parse_activity_events_defaults_outcome_index() {
+        let json = r#"[{
+            "slug": "some-market",
+            "conditionId": "0xabc",
+            "side": "BUY",
+            "price": 0.5,
+            "timestamp": 1000
+        }]"#;
+        let events: Vec<ActivityEvent> = serde_json::from_str(json).unwrap();
+        let trades = parse_activity_events(events);
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].outcome_index, 0);
     }
 
     #[test]

--- a/trading-bot/src/cycles/alerts.rs
+++ b/trading-bot/src/cycles/alerts.rs
@@ -137,7 +137,7 @@ pub async fn alert_loop(
                 let corr_candidates = vec![(
                     signal.market_id.clone(),
                     signal.question.clone(),
-                    signal.side.clone(),
+                    signal.side,
                 )];
                 let corr_decisions =
                     super::portfolio_correlation_check(&scanner, &portfolio, &corr_candidates)
@@ -206,7 +206,7 @@ pub async fn alert_loop(
                     let new_bet = NewBet {
                         market_id: signal.market_id.clone(),
                         question: signal.question.clone(),
-                        side: signal.side.clone(),
+                        side: signal.side,
                         entry_price: signal.current_price,
                         slipped_price,
                         shares,

--- a/trading-bot/src/cycles/bet_scan.rs
+++ b/trading-bot/src/cycles/bet_scan.rs
@@ -194,7 +194,7 @@ pub async fn bet_scan_cycle(
                     (
                         pb.signal.market_id.clone(),
                         pb.signal.question.clone(),
-                        pb.signal.side.clone(),
+                        pb.signal.side,
                     )
                 })
                 .collect();
@@ -249,7 +249,7 @@ pub async fn bet_scan_cycle(
                 let new_bet = NewBet {
                     market_id: signal.market_id.clone(),
                     question: signal.question.clone(),
-                    side: signal.side.clone(),
+                    side: signal.side,
                     entry_price: signal.current_price,
                     slipped_price: pb.slipped_price,
                     shares: pb.shares,

--- a/trading-bot/src/scanner/live.rs
+++ b/trading-bot/src/scanner/live.rs
@@ -1721,7 +1721,7 @@ impl LiveScanner {
     ) -> Result<Vec<CorrelationDecision>> {
         let mut open: Vec<(String, BetSide)> = open_bets
             .iter()
-            .map(|b| (b.question.clone(), b.side.clone()))
+            .map(|b| (b.question.clone(), b.side))
             .collect();
         open.extend(blocked.iter().cloned());
         run_correlation_check(&self.openai_client, &self.cfg.llm_model, candidates, &open).await


### PR DESCRIPTION
Closes #61

### Reason for changes
The copy-bot always opened a **YES** position regardless of which side the followed trader actually bought. The Polymarket `/activity` API returns an `outcomeIndex` (0 = YES token, 1 = NO), but the field was dropped during parsing and `copy_trade.rs` hardcoded `BetSide::Yes`. When a followed trader bought **NO** (e.g. at 0.30), the bot opened a YES position at a mispriced entry — the exact opposite trade. Most financially dangerous bug: turns winners into losers and vice versa.

### Notable changes
- Parse `outcomeIndex` on `ActivityEvent`; carry it on `TraderTrade` (`outcome_index: i64`, defaults to 0 when absent).
- New `BetSide::from_outcome_index` maps 0→YES, 1→NO, and **rejects** multi-outcome markets (index > 1) — the copy path now skips + warns instead of silently coercing them to NO.
- Fixed the price-drift check to compare the trader's entry against the current price of the **traded** side (NO = `1 - yes`), via the new `BetSide::price_from_yes` helper.
- Reused `price_from_yes` at the three pre-existing yes→side conversion sites (`postgres.rs`, `format.rs`), collapsing duplicated math.
- Derived `Copy` on `BetSide`; dropped now-redundant `.clone()` calls.

Downstream settlement/exit/valuation already handled `BetSide::No` correctly — the gap was purely the signal path.

### Testing
- `cargo test --workspace` — new unit tests: `from_outcome_index` binary + multi-outcome rejection, `price_from_yes` complement, and `parse_activity_events` NO-carry + default-index.
- `cargo clippy --workspace` clean.

### Known follow-up (not in this PR)
`is_copy_trade_seen` dedup keys on `(wallet, condition_id, side, price)` — it does not include the outcome token. YES and NO legs of the same market at the same price (e.g. both at 0.50) can collide and be skipped as duplicates. Fixing needs a schema/column change; tracked separately.