### PR TITLE
Honest leak-free backtest harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 CHANGELOG.gen
 .envrc
 tmp/
+
+# local backtest data (pulled from prod, not versioned)
+scripts/model/

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -72,6 +72,9 @@ def compute_lr(model_prob: float, market_price: float) -> float:
     """Likelihood ratio from model vs market."""
     if market_price <= 0.01 or market_price >= 0.99:
         return 1.0
+    # Clamp the model prob away from 0/1 to avoid div-by-zero when the
+    # calibrated model outputs an extreme probability.
+    model_prob = max(0.001, min(0.999, model_prob))
     return (model_prob / market_price) / ((1.0 - model_prob) / (1.0 - market_price))
 
 
@@ -603,12 +606,230 @@ def sweep_stop_loss(df, n_splits=5):
                   f"{delta:>+10.2f}")
 
 
+# --- Honest end-to-end backtest (leak-free, real fills + fees) ---
+
+# Live decision constants (mirror trading-bot): LR is dampened by
+# confidence * LR_DAMPING before the edge floor; YES bets are blocked.
+LR_DAMPING = 0.5
+EDGE_FLOOR = 0.02          # live.rs:1236 effective_edge (edge * conf) floor
+MIN_KELLY = 0.02          # config.rs min_kelly_size
+MIN_BET_PRICE = 0.15      # config.rs min_bet_price
+BLOCK_YES_SIDE = True     # config.rs block_yes_side ("30% WR, -€745 in prod")
+FLAT_BANKROLL = 300.0
+
+
+def _batch_confidence(model, x_test):
+    """Vectorized agreement-based confidence for a whole test matrix at once
+    (same formula as serve_model._estimate_confidence, but one predict_proba
+    per base estimator instead of per row)."""
+    est = model
+    if hasattr(est, "calibrated_classifiers_"):
+        est = est.calibrated_classifiers_[0].estimator
+    base = []
+    if hasattr(est, "estimators_"):
+        for e in est.estimators_:
+            members = e if isinstance(e, list) else [e]
+            for member in members:
+                base.append(member.predict_proba(x_test)[:, 1])
+    if len(base) < 2:
+        return np.full(len(x_test), 0.50)
+    base = np.asarray(base)
+    spread = base.max(axis=0) - base.min(axis=0)
+    return np.clip(0.75 / (1.0 + spread * 4.0), 0.25, 0.75)
+
+
+def run_honest_backtest(df, n_splits=5, strategy="balanced",
+                        block_yes=BLOCK_YES_SIDE, edge_floor=EDGE_FLOOR,
+                        lr_damping=LR_DAMPING):
+    """Leak-free, fee- and fill-aware simulation of the DEPLOYED decision.
+
+    Reproduces live behaviour (LR dampening, gates incl. block_yes_side, the
+    agreement-based confidence) so a profit here would be real.
+    """
+    cached = _materialize_folds(df, n_splits=n_splits)
+    return _evaluate_folds(cached, strategy, block_yes, edge_floor, lr_damping)
+
+
+def run_recalibration_backtest(df, n_splits=5, strategy="balanced", edge_floor=EDGE_FLOOR):
+    """No-ML strategy: bet where a per-(category,horizon) recalibration of the
+    MARKET PRICE diverges from the price. θ fit on train folds only (leak-free
+    via the market-grouped split). Fast — no ensemble training."""
+    from backtest.fees import net_pnl
+    from backtest.fills import fill_price, max_fillable
+    from backtest.metrics import summarize
+    from backtest.recalibration import (category_bucket, fit_theta,
+                                        horizon_bucket, recalibrate)
+    from backtest.walkforward import market_grouped_splits
+
+    s = STRATEGIES[strategy]
+    price = df["yes_price"].astype(float).values
+    outcome = df["label"].astype(int).values
+    dte = df["days_to_expiry"].astype(float).values
+    catcol = df["category"] if "category" in df else df["question"]
+    cats = [category_bucket(str(c)) for c in catcol.values]
+    bucket = np.array([f"{c}|{horizon_bucket(d)}" for c, d in zip(cats, dte)])
+    vol = df["volume"].astype(float)
+    liq = vol.fillna(vol.median()).clip(lower=0.0).values
+    mid = df["market_id"].values
+    ts = df["snapshot_ts"].values if "snapshot_ts" in df else np.arange(len(df))
+
+    bets = []
+    funnel = {"priced": 0, "no_edge": 0, "edge_floor": 0, "min_price": 0,
+              "min_kelly": 0, "stake_too_small": 0, "placed": 0}
+    theta_log = {}
+
+    for train_mask, test_mask in market_grouped_splits(mid, ts, n_splits):
+        thetas = {}
+        for b in np.unique(bucket[train_mask]):
+            m = train_mask & (bucket == b)
+            thetas[b] = fit_theta(price[m], outcome[m])
+            theta_log.setdefault(b, []).append(thetas[b])
+        for i in np.nonzero(test_mask)[0]:
+            p = float(price[i])
+            if p <= 0.01 or p >= 0.99:
+                continue
+            funnel["priced"] += 1
+            post = float(recalibrate(p, thetas.get(bucket[i], 1.0)))
+            yes_edge = post - p
+            no_edge = (1.0 - post) - (1.0 - p)
+            if yes_edge >= no_edge and yes_edge > 0:
+                side, edge, bet_price, bet_prob, won = "YES", yes_edge, p, post, outcome[i] == 1
+            elif no_edge > 0:
+                side, edge, bet_price, bet_prob, won = "NO", no_edge, 1.0 - p, 1.0 - post, outcome[i] == 0
+            else:
+                funnel["no_edge"] += 1
+                continue
+            if edge < edge_floor:
+                funnel["edge_floor"] += 1
+                continue
+            if bet_price < MIN_BET_PRICE:
+                funnel["min_price"] += 1
+                continue
+            k = fractional_kelly(bet_prob, bet_price, s["kelly_frac"])
+            if k < MIN_KELLY:
+                funnel["min_kelly"] += 1
+                continue
+            stake = min(FLAT_BANKROLL * k, max_fillable(liq[i]))
+            if stake < 0.50:
+                funnel["stake_too_small"] += 1
+                continue
+            funnel["placed"] += 1
+            filled = fill_price(bet_price, stake, liq[i])
+            pnl = net_pnl(stake, filled, won)
+            bets.append({"stake": stake, "entry_fee": stake * 0.02, "pnl": pnl,
+                         "won": won, "model_prob": post, "market_price": p,
+                         "outcome": int(outcome[i])})
+
+    out = summarize(bets)
+    out["funnel"] = funnel
+    out["theta_by_bucket"] = {b: round(float(np.mean(v)), 2) for b, v in sorted(theta_log.items())}
+    out["pnls"] = [b["pnl"] for b in bets]
+    return out
+
+
+def _materialize_folds(df, n_splits=5):
+    """Train the (expensive) per-fold models ONCE and cache each fold's
+    predictions + test arrays, so many gate configs evaluate cheaply."""
+    from backtest.walkforward import walk_forward
+    cached = []
+    for fold in walk_forward(df, FEATURE_COLS, n_splits=n_splits):
+        cached.append({
+            "probs": fold.model.predict_proba(fold.x_test_scaled)[:, 1],
+            "confs": _batch_confidence(fold.model, fold.x_test_scaled),
+            "prices": fold.prices_test,
+            "outcomes": fold.y_test,
+            "liq": fold.liquidity_test,
+        })
+    return cached
+
+
+def _evaluate_folds(cached, strategy="balanced", block_yes=BLOCK_YES_SIDE,
+                    edge_floor=EDGE_FLOOR, lr_damping=LR_DAMPING):
+    """Replay the deployed decision over cached folds under one gate config."""
+    from backtest.fees import net_pnl
+    from backtest.fills import fill_price, max_fillable
+    from backtest.metrics import summarize
+
+    s = STRATEGIES[strategy]
+    bets = []
+    funnel = {"priced": 0, "no_edge": 0, "block_yes": 0, "edge_floor": 0,
+              "min_price": 0, "min_kelly": 0, "stake_too_small": 0, "placed": 0}
+
+    for fold in cached:
+        probs, confs = fold["probs"], fold["confs"]
+        for i in range(len(probs)):
+            prob = float(probs[i])
+            price = float(fold["prices"][i])
+            outcome = int(fold["outcomes"][i])
+            liq = float(fold["liq"][i])
+            if price <= 0.01 or price >= 0.99:
+                continue
+            funnel["priced"] += 1
+
+            conf = float(confs[i])
+            lr = compute_lr(prob, price)
+            post = bayesian_posterior(price, lr, conf * lr_damping)
+
+            yes_edge = post - price
+            no_edge = (1.0 - post) - (1.0 - price)
+            if yes_edge >= no_edge and yes_edge > 0:
+                side, edge, bet_price, bet_prob, won = "YES", yes_edge, price, post, outcome == 1
+            elif no_edge > 0:
+                side, edge, bet_price, bet_prob, won = "NO", no_edge, 1.0 - price, 1.0 - post, outcome == 0
+            else:
+                funnel["no_edge"] += 1
+                continue
+
+            if block_yes and side == "YES":
+                funnel["block_yes"] += 1
+                continue
+            if edge * conf < edge_floor:
+                funnel["edge_floor"] += 1
+                continue
+            if bet_price < MIN_BET_PRICE:
+                funnel["min_price"] += 1
+                continue
+
+            k = fractional_kelly(bet_prob, bet_price, s["kelly_frac"])
+            if k < MIN_KELLY:
+                funnel["min_kelly"] += 1
+                continue
+
+            stake = min(FLAT_BANKROLL * k, max_fillable(liq))
+            if stake < 0.50:
+                funnel["stake_too_small"] += 1
+                continue
+
+            funnel["placed"] += 1
+            filled = fill_price(bet_price, stake, liq)
+            entry_fee = stake * 0.02
+            pnl = net_pnl(stake, filled, won)
+            bets.append({
+                "stake": stake, "entry_fee": entry_fee, "pnl": pnl, "won": won,
+                "model_prob": prob, "market_price": price, "outcome": outcome,
+            })
+
+    out = summarize(bets)
+    out["funnel"] = funnel
+    return out
+
+
 def main():
     parser = argparse.ArgumentParser(description="Backtest with Bayesian anchoring")
     parser.add_argument("--input", default="model/training_data.json")
     parser.add_argument("--folds", type=int, default=5)
-    parser.add_argument("--sweep", action="store_true", help="Sweep conservative params")
-    parser.add_argument("--stop-loss", action="store_true", help="Compare stop-loss levels")
+    parser.add_argument("--honest", action="store_true",
+                        help="Leak-free, fee/fill-aware honest backtest (default)")
+    parser.add_argument("--sweep", action="store_true", help="Sweep conservative params (LEAKY — exploratory only)")
+    parser.add_argument("--stop-loss", action="store_true", help="Compare stop-loss levels (LEAKY — exploratory only)")
+    parser.add_argument("--legacy", action="store_true",
+                        help="Old OLD-vs-NEW comparison (LEAKY scaler — exploratory only)")
+    parser.add_argument("--landscape", action="store_true",
+                        help="Train folds once, sweep gate configs (block_yes / edge_floor / lr_damping)")
+    parser.add_argument("--recal", action="store_true",
+                        help="No-ML market-price recalibration strategy (per category x horizon)")
+    parser.add_argument("--diagnose", action="store_true",
+                        help="Learning-curve + permutation (data vs signal) and FLB robustness")
     args = parser.parse_args()
 
     df = load_data(args.input)
@@ -617,15 +838,93 @@ def main():
         sys.exit(1)
 
     if args.sweep:
+        print("WARNING: sweep uses pre-split scaling (look-ahead leakage) — exploratory only.\n")
         print(f"Sweeping conservative params on {len(df)} samples, {args.folds} folds")
         sweep_conservative(df, n_splits=args.folds)
     elif args.stop_loss:
+        print("WARNING: stop-loss sweep uses pre-split scaling (look-ahead leakage) — exploratory only.\n")
         print(f"Comparing stop-loss levels on {len(df)} samples, {args.folds} folds")
         sweep_stop_loss(df, n_splits=args.folds)
-    else:
-        print(f"Running backtest on {len(df)} samples across {args.folds} folds")
-        print(f"Comparing: OLD (raw model prob) vs NEW (Bayesian-anchored)")
+    elif args.legacy:
+        print("WARNING: legacy path fits the scaler on ALL rows (look-ahead leakage) — exploratory only.\n")
         run_backtest(df, n_splits=args.folds)
+    elif args.diagnose:
+        from backtest.diagnostics import flb_robustness, learning_and_permutation
+        print(f"Signal diagnostics on {len(df)} samples\n")
+        print("A) Learning curve + permutation (Brier skill vs market; >0 = real signal)")
+        try:
+            curve, real, perm = learning_and_permutation(df, FEATURE_COLS)
+            print(f"   learning curve (train frac -> skill): {curve}")
+            pmean = sum(perm) / len(perm)
+            pmax = max(perm)
+            print(f"   real skill (full train): {real:+.4f}")
+            print(f"   permutation null: mean={pmean:+.4f} max={pmax:+.4f}  (n={len(perm)})")
+            verdict = ("SIGNAL: real skill clears the shuffled-label null"
+                       if real > pmax and real > 0 else
+                       "NO SIGNAL beyond price: real skill within/under the null")
+            print(f"   => {verdict}")
+        except ValueError as e:
+            print(f"   skipped: {e}")
+        print("\nB) FLB (recalibration) robustness")
+        r = run_recalibration_backtest(df, n_splits=args.folds, strategy="balanced")
+        rob = flb_robustness(r.get("pnls", []))
+        print(f"   total=€{rob['total']}  ex_top5=€{rob['ex_top5']}  ex_top20=€{rob['ex_top20']}")
+        print(f"   bootstrap 95% CI on total PnL: {rob['boot_ci95']}")
+        ci_lo = rob["boot_ci95"][0]
+        print(f"   => {'ROBUST: CI lower bound > 0' if ci_lo > 0 else 'FRAGILE: CI includes 0/negative — not a reliable edge'}")
+    elif args.recal:
+        print(f"Recalibration backtest on {len(df)} samples, {args.folds} folds "
+              f"(no ML; θ per category×horizon, fit on train only)")
+        for strategy in ("aggressive", "balanced", "conservative"):
+            r = run_recalibration_backtest(df, n_splits=args.folds, strategy=strategy)
+            print(f"\n[{strategy.upper()}]")
+            print(f"  bets={r['n']}  net_pnl=€{r.get('net_pnl', 0):+.2f}  "
+                  f"net_roi={r.get('net_roi_pct', 0):+.1f}%  "
+                  f"win_rate={r.get('win_rate', 0):.0%}  "
+                  f"brier_skill_vs_market={r.get('brier_skill_vs_market', 0):+.2f}  "
+                  f"max_dd=€{r.get('max_drawdown', 0):.2f}")
+            if strategy == "balanced":
+                print(f"  funnel: {r.get('funnel', {})}")
+                print(f"  θ by bucket: {r.get('theta_by_bucket', {})}")
+                pnls = sorted(r.get("pnls", []), reverse=True)
+                if pnls:
+                    total = sum(pnls)
+                    top5 = sum(pnls[:5])
+                    ex_top5 = total - top5
+                    wins = [p for p in pnls if p > 0]
+                    print(f"  concentration: total=€{total:+.0f}  top5_wins=€{top5:+.0f} "
+                          f"({(top5 / total * 100 if total else 0):.0f}% of net)  "
+                          f"net_excl_top5=€{ex_top5:+.0f}  n_wins={len(wins)}")
+    elif args.landscape:
+        print(f"Landscape sweep on {len(df)} samples, {args.folds} folds "
+              f"(training once, replaying gate configs)")
+        cached = _materialize_folds(df, n_splits=args.folds)
+        configs = [
+            ("base: block_yes, floor .02, damp .5", dict(block_yes=True, edge_floor=0.02, lr_damping=0.5)),
+            ("allow_yes", dict(block_yes=False, edge_floor=0.02, lr_damping=0.5)),
+            ("trust model (damp 1.0)", dict(block_yes=True, edge_floor=0.02, lr_damping=1.0)),
+            ("trust market (damp 0.2)", dict(block_yes=True, edge_floor=0.02, lr_damping=0.2)),
+            ("higher floor .05", dict(block_yes=True, edge_floor=0.05, lr_damping=0.5)),
+            ("allow_yes + damp 1.0", dict(block_yes=False, edge_floor=0.02, lr_damping=1.0)),
+            ("allow_yes + floor .05 + damp 1.0", dict(block_yes=False, edge_floor=0.05, lr_damping=1.0)),
+        ]
+        print(f"\n{'config':<40s} {'bets':>6s} {'net_pnl':>10s} {'roi%':>7s} {'win%':>5s} {'skill':>6s}")
+        for label, cfg in configs:
+            r = _evaluate_folds(cached, strategy="balanced", **cfg)
+            print(f"{label:<40s} {r['n']:>6d} {r.get('net_pnl', 0):>+10.0f} "
+                  f"{r.get('net_roi_pct', 0):>+6.1f}% {r.get('win_rate', 0)*100:>4.0f}% "
+                  f"{r.get('brier_skill_vs_market', 0):>+6.2f}")
+    else:
+        print(f"Honest backtest on {len(df)} samples across {args.folds} folds")
+        for strategy in ("aggressive", "balanced", "conservative"):
+            r = run_honest_backtest(df, n_splits=args.folds, strategy=strategy)
+            print(f"\n[{strategy.upper()}]")
+            print(f"  bets={r['n']}  net_pnl=€{r.get('net_pnl', 0):+.2f}  "
+                  f"net_roi={r.get('net_roi_pct', 0):+.1f}%  "
+                  f"win_rate={r.get('win_rate', 0):.0%}  "
+                  f"brier_skill_vs_market={r.get('brier_skill_vs_market', 0):+.2f}  "
+                  f"max_dd=€{r.get('max_drawdown', 0):.2f}")
+            print(f"  funnel: {r.get('funnel', {})}")
 
 
 if __name__ == "__main__":

--- a/scripts/backtest/diagnostics.py
+++ b/scripts/backtest/diagnostics.py
@@ -1,0 +1,98 @@
+"""Signal diagnostics for the honest harness.
+
+A) learning curve + permutation test — is a null result data-limited or
+   signal-limited? Uses a FAST single model (LightGBM) so we can afford many
+   fits. Skill = Brier skill vs the market price on a held-out market-grouped
+   test fold.
+B) FLB robustness — per-fold consistency + bootstrap CI + ex-outlier PnL for
+   the recalibration strategy, so we know if its edge is real or a few wins.
+"""
+
+import numpy as np
+
+from backtest.metrics import brier_skill_vs_market
+from backtest.walkforward import market_grouped_splits
+
+LEAK_COLS = ("price_change_1d", "price_change_1w")
+
+
+def _prep(df, feature_cols):
+    from train_model import build_feature_matrix
+    x = build_feature_matrix(df).reset_index(drop=True)
+    for c in LEAK_COLS:
+        if c in x.columns:
+            x[c] = 0.0
+    y = np.asarray(df["label"].values, int)
+    price = np.asarray(df["yes_price"].values, float)
+    mid = df["market_id"].values
+    ts = df["snapshot_ts"].values if "snapshot_ts" in df else np.arange(len(df))
+    return x, y, price, mid, ts
+
+
+def _fast_fit_predict(x_tr, y_tr, x_te):
+    import lightgbm as lgb
+    m = lgb.LGBMClassifier(n_estimators=150, num_leaves=31, learning_rate=0.05,
+                           subsample=0.8, colsample_bytree=0.8, verbosity=-1)
+    m.fit(x_tr, y_tr)
+    return m.predict_proba(x_te)[:, 1]
+
+
+def learning_and_permutation(df, feature_cols, fractions=(0.25, 0.5, 1.0),
+                             n_perm=10, seed_base=0):
+    """Returns (learning_curve, real_skill, perm_skills). Single leave-out
+    market-grouped fold (last block = test)."""
+    x, y, price, mid, ts = _prep(df, feature_cols)
+    # take the LAST fold from a 4-way market split as the held-out test
+    folds = list(market_grouped_splits(mid, ts, n_splits=4))
+    if not folds:
+        raise ValueError(
+            "insufficient markets for diagnostics (need > 5 distinct markets)"
+        )
+    train_mask, test_mask = folds[-1]
+    xtr_all, ytr_all = x[train_mask], y[train_mask]
+    xte, yte, pte = x[test_mask], y[test_mask], price[test_mask]
+
+    # learning curve: train on the LAST fraction of train markets (time-ordered)
+    tr_idx = np.nonzero(train_mask)[0]
+    curve = {}
+    for f in fractions:
+        k = max(200, int(len(tr_idx) * f))
+        sub = tr_idx[-k:]
+        probs = _fast_fit_predict(x.loc[sub], y[sub], xte)
+        curve[f] = round(brier_skill_vs_market(probs, pte, yte), 4)
+
+    # full-data real skill
+    real = curve[fractions[-1]]
+
+    # permutation null: shuffle train labels (market-level indices already mixed
+    # in train; a plain shuffle breaks any feature->label link)
+    perm = []
+    for j in range(n_perm):
+        rng = np.random.RandomState(seed_base + j + 1)
+        yperm = ytr_all.copy()
+        rng.shuffle(yperm)
+        probs = _fast_fit_predict(xtr_all, yperm, xte)
+        perm.append(round(brier_skill_vs_market(probs, pte, yte), 4))
+    return curve, real, perm
+
+
+def flb_robustness(pnls_list, n_boot=1000):
+    """Bootstrap CI + ex-top-k for a strategy's per-bet PnL list."""
+    pnls = np.array(sorted(pnls_list, reverse=True))
+    total = float(pnls.sum())
+    ex5 = float(pnls[5:].sum()) if len(pnls) > 5 else 0.0
+    ex20 = float(pnls[20:].sum()) if len(pnls) > 20 else 0.0
+
+    # bootstrap CI on total PnL (resample bets with replacement)
+    rng = np.random.RandomState(0)
+    boots = []
+    n = len(pnls)
+    if n > 0:
+        for _ in range(n_boot):
+            samp = pnls[rng.randint(0, n, n)]
+            boots.append(samp.sum())
+        lo, hi = np.percentile(boots, [2.5, 97.5])
+    else:
+        lo = hi = 0.0
+    return {"n": n, "total": round(total, 1), "ex_top5": round(ex5, 1),
+            "ex_top20": round(ex20, 1), "boot_ci95": (round(float(lo), 1), round(float(hi), 1))}

--- a/scripts/backtest/fees.py
+++ b/scripts/backtest/fees.py
@@ -1,0 +1,24 @@
+"""Fee-accurate realized PnL for one resolved bet.
+
+Matches live accounting in common/src/storage/postgres.rs:1013-1018:
+- 2% entry fee on the stake,
+- 2% exit fee on the gross payout,
+- a win pays shares (= stake / bet_price) at $1 each.
+"""
+
+
+def net_pnl(stake, bet_price, won, entry_fee_rate=0.02, exit_fee_rate=0.02):
+    """Realized PnL for one resolved bet.
+
+    `bet_price` is the price paid on the bet's own side (for a NO bet, pass the
+    NO price, i.e. 1 - yes_price). On a loss the whole stake plus entry fee is
+    lost (a zero payout incurs no exit fee).
+    """
+    if bet_price <= 0.0 or bet_price >= 1.0 or stake <= 0.0:
+        return 0.0
+    entry_fee = stake * entry_fee_rate
+    if won:
+        payout = stake / bet_price          # shares * $1
+        exit_fee = payout * exit_fee_rate
+        return payout - exit_fee - stake - entry_fee
+    return -(stake + entry_fee)

--- a/scripts/backtest/fills.py
+++ b/scripts/backtest/fills.py
@@ -1,0 +1,21 @@
+"""Conservative fill / slippage model.
+
+The Data-API price history we backtest on has no L2 depth, so this is a
+deliberately conservative proxy anchored to the slippage we actually measured
+live (baseline doc: p95 = 0.0072). Price impact grows with the stake's share of
+available liquidity; a bet is also capped at a fraction of that liquidity.
+"""
+
+
+def max_fillable(liquidity_usd, participation=0.10):
+    """Cap a bet at a fraction of available liquidity."""
+    return max(0.0, liquidity_usd * participation)
+
+
+def fill_price(quoted, stake, liquidity_usd, slippage_floor=0.0072):
+    """Effective price paid, always >= quoted, clamped below 0.99."""
+    if liquidity_usd <= 0.0:
+        impact = slippage_floor
+    else:
+        impact = slippage_floor + 0.05 * (stake / liquidity_usd)
+    return min(0.99, quoted + impact)

--- a/scripts/backtest/metrics.py
+++ b/scripts/backtest/metrics.py
@@ -1,0 +1,51 @@
+"""Honest backtest metrics: net ROI, Brier skill vs market, drawdown, baseline."""
+
+import numpy as np
+
+
+def brier(probs, outcomes):
+    p, o = np.asarray(probs, float), np.asarray(outcomes, float)
+    return float(np.mean((p - o) ** 2))
+
+
+def brier_skill_vs_market(model_probs, market_prices, outcomes):
+    """1 - model_brier / market_brier. Negative means worse than the price."""
+    mb = brier(model_probs, outcomes)
+    kb = brier(market_prices, outcomes)
+    return float(1.0 - mb / kb) if kb > 0 else 0.0
+
+
+def max_drawdown(pnl_series):
+    """Largest peak-to-trough drop of a cumulative PnL series."""
+    s = np.asarray(pnl_series, float)
+    if len(s) == 0:
+        return 0.0
+    peak = np.maximum.accumulate(s)
+    return float(np.max(peak - s))
+
+
+def summarize(bets):
+    """bets: list of dicts with stake, entry_fee, pnl, won, model_prob,
+    market_price, outcome. Returns an honest summary including net ROI on
+    capital-at-risk (stake + entry fee) and a no-bet baseline."""
+    if not bets:
+        return {"n": 0, "net_pnl": 0.0, "net_roi_pct": 0.0}
+    stake = sum(b["stake"] + b["entry_fee"] for b in bets)
+    pnl = sum(b["pnl"] for b in bets)
+    cum, run = [], 0.0
+    for b in bets:
+        run += b["pnl"]
+        cum.append(run)
+    return {
+        "n": len(bets),
+        "net_pnl": pnl,
+        "net_roi_pct": (pnl / stake * 100.0) if stake > 0 else 0.0,
+        "win_rate": sum(1 for b in bets if b["won"]) / len(bets),
+        "brier_skill_vs_market": brier_skill_vs_market(
+            [b["model_prob"] for b in bets],
+            [b["market_price"] for b in bets],
+            [b["outcome"] for b in bets],
+        ),
+        "max_drawdown": max_drawdown(cum),
+        "baseline_no_bet_pnl": 0.0,
+    }

--- a/scripts/backtest/recalibration.py
+++ b/scripts/backtest/recalibration.py
@@ -1,0 +1,61 @@
+"""Market-price recalibration (Le 2026): p* = p^θ / (p^θ + (1-p)^θ).
+
+θ > 1 extremizes (market underconfident → push toward 0/1);
+θ < 1 shrinks toward 0.5 (market overconfident). θ is fit per
+(category, horizon) bucket by minimizing log-loss on TRAIN outcomes only.
+"""
+
+import numpy as np
+
+
+def recalibrate(p, theta):
+    """Apply the power/odds recalibration. Vectorized; clamps p away from 0/1."""
+    p = np.clip(np.asarray(p, float), 1e-6, 1 - 1e-6)
+    pt = p ** theta
+    return pt / (pt + (1 - p) ** theta)
+
+
+def _logloss(p, y):
+    p = np.clip(p, 1e-9, 1 - 1e-9)
+    y = np.asarray(y, float)
+    return float(-np.mean(y * np.log(p) + (1 - y) * np.log(1 - p)))
+
+
+def fit_theta(prices, outcomes, lo=0.3, hi=3.0, steps=54):
+    """Fit θ minimizing recalibrated log-loss on (prices, outcomes).
+
+    Returns 1.0 (no-op) when there is too little data to fit reliably.
+    Uses a coarse grid + local refine — no scipy dependency.
+    """
+    prices = np.asarray(prices, float)
+    outcomes = np.asarray(outcomes, float)
+    if len(prices) < 50:
+        return 1.0
+    grid = np.linspace(lo, hi, steps)
+    losses = [_logloss(recalibrate(prices, t), outcomes) for t in grid]
+    best = grid[int(np.argmin(losses))]
+    # local refine around the grid winner
+    fine = np.linspace(max(lo, best - 0.1), min(hi, best + 0.1), 21)
+    losses_f = [_logloss(recalibrate(prices, t), outcomes) for t in fine]
+    return float(fine[int(np.argmin(losses_f))])
+
+
+def category_bucket(cat):
+    """Coarse category from the raw snapshot `category`/`question` string."""
+    c = (cat or "").lower()
+    if any(k in c for k in ("crypto", "bitcoin", "btc", "eth", "solana")):
+        return "crypto"
+    if any(k in c for k in ("nba", "nfl", "mlb", "nhl", "soccer", "sport", "ufc", "tennis", "game")):
+        return "sports"
+    if any(k in c for k in ("elect", "president", "senate", "poll", "trump", "politic")):
+        return "politics"
+    return "other"
+
+
+def horizon_bucket(days_to_expiry):
+    d = float(days_to_expiry)
+    if d < 3:
+        return "<3d"
+    if d < 7:
+        return "3-7d"
+    return "7-14d"

--- a/scripts/backtest/walkforward.py
+++ b/scripts/backtest/walkforward.py
@@ -1,0 +1,108 @@
+"""Leak-free walk-forward.
+
+The scaler and the model are fit on the TRAIN slice of each fold only — never
+on data that includes the test slice. This is the honesty fix for the old
+`backtest.py`, which fit the RobustScaler on all rows before splitting.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import RobustScaler
+
+
+def fit_scaler_on_train(x_train):
+    """Fit a RobustScaler on the train slice only."""
+    scaler = RobustScaler()
+    scaler.fit(x_train)
+    return scaler
+
+
+@dataclass
+class Fold:
+    model: object
+    x_test_scaled: pd.DataFrame
+    y_test: np.ndarray
+    prices_test: np.ndarray
+    liquidity_test: np.ndarray
+
+
+def market_grouped_splits(market_ids, snapshot_ts, n_splits=5):
+    """Expanding-window folds grouped by market and ordered by first-seen time.
+
+    All snapshots of a market land on ONE side of the split — critical because
+    every snapshot of a market shares that market's final outcome as its label,
+    so a snapshot-level (or time-level) split leaks the label across the same
+    market's rows. Yields (train_mask, test_mask) boolean arrays.
+    """
+    mid = np.asarray(market_ids)
+    ts = np.asarray(snapshot_ts)
+    first_seen = {}
+    for m, t in zip(mid, ts):
+        if m not in first_seen or t < first_seen[m]:
+            first_seen[m] = t
+    markets = sorted(first_seen, key=lambda m: first_seen[m])
+    n_m = len(markets)
+    block = n_m // (n_splits + 1)
+    if block == 0:
+        return
+    for k in range(1, n_splits + 1):
+        train_markets = set(markets[: block * k])
+        test_markets = set(markets[block * k : block * (k + 1)])
+        if not test_markets:
+            continue
+        yield (
+            np.array([m in train_markets for m in mid]),
+            np.array([m in test_markets for m in mid]),
+        )
+
+
+def walk_forward(df, feature_cols, n_splits=5):
+    """Yield market-grouped folds; scaler + calibrated model fit on train only."""
+    # Lazy import so the scaler helper (and its unit test) don't require the
+    # full ML stack.
+    from sklearn.calibration import CalibratedClassifierCV
+
+    from train_model import build_ensemble, build_feature_matrix
+
+    x = build_feature_matrix(df).reset_index(drop=True)  # unscaled
+    # Neutralize settled-delta features: in the training data (closed markets)
+    # price_change_1d/1w come from the resolved market's Gamma field, so they
+    # encode the outcome — a leak that inflates any historical eval. (These are
+    # also dropped by the model-fixes plan.)
+    for _leak in ("price_change_1d", "price_change_1w"):
+        if _leak in x.columns:
+            x[_leak] = 0.0
+    y = np.asarray(df["label"].values)
+    prices = np.asarray(df["yes_price"].values)
+    # Liquidity proxy = market dollar volume (the `liquidity` column is unpopulated
+    # in the training data). NaN volumes fall back to the median so they aren't
+    # silently dropped. Real order-book depth is the S2 spike.
+    if "volume" in df:
+        vol = df["volume"].astype(float)
+        liq = vol.fillna(vol.median()).clip(lower=0.0).values
+    else:
+        liq = np.full(len(df), 1e4)
+
+    market_ids = df["market_id"].values
+    snapshot_ts = df["snapshot_ts"].values if "snapshot_ts" in df else np.arange(len(df))
+
+    for train_mask, test_mask in market_grouped_splits(market_ids, snapshot_ts, n_splits):
+        x_train, x_test = x[train_mask], x[test_mask]
+        scaler = fit_scaler_on_train(x_train)  # TRAIN ONLY
+        x_tr = pd.DataFrame(scaler.transform(x_train), columns=feature_cols)
+        x_te = pd.DataFrame(scaler.transform(x_test), columns=feature_cols)
+        raw = build_ensemble()
+        n_train = int(train_mask.sum())
+        method = "isotonic" if n_train > 1000 else "sigmoid"
+        cv = min(3, max(2, n_train // 200))
+        model = CalibratedClassifierCV(raw, method=method, cv=cv, ensemble=True)
+        model.fit(x_tr, y[train_mask])
+        yield Fold(
+            model=model,
+            x_test_scaled=x_te,
+            y_test=y[test_mask],
+            prices_test=prices[test_mask],
+            liquidity_test=liq[test_mask],
+        )

--- a/scripts/test_backtest.py
+++ b/scripts/test_backtest.py
@@ -1,0 +1,124 @@
+"""Tests for the honest backtest harness modules."""
+
+import numpy as np
+import pandas as pd
+
+from backtest.fees import net_pnl
+from backtest.fills import fill_price, max_fillable
+from backtest.metrics import brier, brier_skill_vs_market, max_drawdown, summarize
+from backtest.recalibration import fit_theta, recalibrate
+from backtest.walkforward import fit_scaler_on_train, market_grouped_splits
+
+
+def test_net_pnl_win_matches_live_formula():
+    # stake 100 @ price 0.5, win: payout=200, exit fee=4, pnl=200-4-100-2=94
+    assert abs(net_pnl(100.0, 0.5, True) - 94.0) < 1e-6
+
+
+def test_net_pnl_loss_is_stake_plus_entry_fee():
+    assert abs(net_pnl(100.0, 0.5, False) - (-102.0)) < 1e-6
+
+
+def test_net_pnl_degenerate_prices_return_zero():
+    assert net_pnl(100.0, 0.0, True) == 0.0
+    assert net_pnl(100.0, 1.0, True) == 0.0
+    assert net_pnl(0.0, 0.5, True) == 0.0
+
+
+def test_fill_price_worse_than_quoted():
+    p = fill_price(0.50, stake=100.0, liquidity_usd=10_000.0)
+    assert 0.50 < p < 0.60
+
+
+def test_fill_price_floor_applies_on_tiny_size():
+    # even a negligible order pays at least the measured live floor
+    p = fill_price(0.50, stake=1.0, liquidity_usd=1_000_000.0)
+    assert p >= 0.50 + 0.0072 - 1e-9
+    assert p <= 0.50 + 0.0072 + 1e-4  # extra impact is negligible
+
+
+def test_fill_price_no_liquidity_uses_floor():
+    assert abs(fill_price(0.30, stake=100.0, liquidity_usd=0.0) - (0.30 + 0.0072)) < 1e-9
+
+
+def test_fill_price_clamped_below_one():
+    assert fill_price(0.985, stake=100.0, liquidity_usd=1.0) <= 0.99
+
+
+def test_max_fillable_caps_at_participation():
+    assert abs(max_fillable(10_000.0, participation=0.10) - 1_000.0) < 1e-6
+
+
+def test_scaler_fit_on_train_only():
+    # RobustScaler center = median of the train slice, so a huge value that
+    # would only appear in a later (test) fold cannot shift it.
+    train = pd.DataFrame({"f": np.arange(100.0)})
+    scaler = fit_scaler_on_train(train)
+    assert abs(scaler.center_[0] - 49.5) < 1e-6
+    # a test-fold outlier is irrelevant: fitting on train alone is unchanged
+    scaler2 = fit_scaler_on_train(train)
+    assert np.allclose(scaler.center_, scaler2.center_)
+    assert np.allclose(scaler.scale_, scaler2.scale_)
+
+
+def test_brier_perfect_is_zero():
+    assert brier([1.0, 0.0], [1, 0]) == 0.0
+
+
+def test_brier_skill_negative_when_worse_than_market():
+    # model always 0.5; market is nearly right → skill < 0
+    assert brier_skill_vs_market([0.5, 0.5], [0.9, 0.1], [1, 0]) < 0
+
+
+def test_max_drawdown_basic():
+    assert abs(max_drawdown([10, 5, 8, 2, 6]) - 8.0) < 1e-9
+
+
+def test_summarize_net_roi_and_baseline():
+    bets = [
+        {"stake": 100.0, "entry_fee": 2.0, "pnl": 94.0, "won": True,
+         "model_prob": 0.7, "market_price": 0.5, "outcome": 1},
+        {"stake": 100.0, "entry_fee": 2.0, "pnl": -102.0, "won": False,
+         "model_prob": 0.7, "market_price": 0.5, "outcome": 0},
+    ]
+    s = summarize(bets)
+    assert s["n"] == 2
+    assert abs(s["net_pnl"] - (-8.0)) < 1e-9
+    # net ROI on capital-at-risk (2 * 102) = -8 / 204 * 100
+    assert abs(s["net_roi_pct"] - (-8.0 / 204.0 * 100.0)) < 1e-6
+    assert s["baseline_no_bet_pnl"] == 0.0
+
+
+def test_summarize_empty():
+    assert summarize([])["n"] == 0
+
+
+def test_recalibrate_fixed_point_and_direction():
+    assert abs(recalibrate(0.5, 2.0) - 0.5) < 1e-9   # 0.5 is a fixed point
+    assert recalibrate(0.7, 1.5) > 0.7               # theta>1 extremizes
+    assert recalibrate(0.7, 0.5) < 0.7               # theta<1 shrinks to 0.5
+
+
+def test_fit_theta_detects_underconfidence():
+    # market prints 0.70 but YES actually resolves ~90% → underconfident → theta>1
+    rng = np.random.RandomState(0)
+    prices = np.full(400, 0.70)
+    outcomes = (rng.random(400) < 0.90).astype(int)
+    assert fit_theta(prices, outcomes) > 1.0
+
+
+def test_fit_theta_too_few_samples_is_noop():
+    assert fit_theta([0.6] * 10, [1] * 10) == 1.0
+
+
+def test_market_grouped_split_no_market_spans_sides():
+    # 6 markets, 2 snapshots each — no market may appear on both sides
+    mids = [m for m in ["a", "b", "c", "d", "e", "f"] for _ in range(2)]
+    ts = list(range(12))
+    folds = list(market_grouped_splits(mids, ts, n_splits=2))
+    assert len(folds) >= 1
+    for train_mask, test_mask in folds:
+        train_markets = {m for m, keep in zip(mids, train_mask) if keep}
+        test_markets = {m for m, keep in zip(mids, test_mask) if keep}
+        assert train_markets.isdisjoint(test_markets)
+        assert test_markets  # non-empty test side


### PR DESCRIPTION
## Summary
Adds a leak-free, fee- and fill-aware backtest harness for the ML model, plus signal diagnostics. Python-only (`scripts/backtest/`), no migrations, no runtime/bot changes.

## What
- **Leak-free market-grouped walk-forward** — no market's snapshots span train/test (the old time/snapshot split leaked each market's outcome across its snapshots).
- **Fee/fill-aware simulation** — net PnL matching live accounting (2% entry + 2% exit), conservative slippage + liquidity cap.
- **Honest metrics** — net ROI, Brier skill vs market, max drawdown, no-bet baseline; a rejection funnel so a 0-bet run is explained.
- **Extras** — `--recal` (market-price recalibration strategy), `--landscape` (gate-config sweep, trains once), `--diagnose` (learning-curve + permutation test, FLB bootstrap robustness).
- Old leaky paths retained as `--legacy/--sweep`, explicitly marked look-ahead-leaky.

## Why
The pre-existing backtest fit the scaler on all rows before splitting and used a fabricated fill model, so it never caught the model's live losses. This harness exposed two label leaks that had inflated all prior CV metrics.

## Testing
18 unit tests (`scripts/test_backtest.py`) green. No Rust/runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)