### PR TITLE
ML pipeline: fix warm-start + reduce train/serve skew

### DIFF
--- a/common/src/model/features.rs
+++ b/common/src/model/features.rs
@@ -209,8 +209,11 @@ impl MarketFeatures {
         };
 
         // Gamma API price changes (fallback to computed momentum)
-        let price_change_1d = market.one_day_price_change.unwrap_or(momentum_24h);
-        let price_change_1w = market.one_week_price_change.unwrap_or(0.0);
+        // Neutralized (0): in training these came from CLOSED markets' settled
+        // Gamma deltas and encoded the outcome (a leak). Zeroed at train + serve
+        // so the model can't rely on them. See ADR 011.
+        let price_change_1d = 0.0;
+        let price_change_1w = 0.0;
 
         // NLP features from question text
         let nlp = extract_nlp_features(&market.question);
@@ -274,7 +277,8 @@ fn extract_nlp_features(question: &str) -> NlpFeatures {
     let n_words = words.len().max(1) as f64;
     let unique: std::collections::HashSet<&str> = words.iter().copied().collect();
 
-    let q_length = question.len() as f64;
+    // char count (not bytes) to match Python len() in training on non-ASCII text.
+    let q_length = question.chars().count() as f64;
     let q_word_count = n_words;
     let q_avg_word_len = words.iter().map(|w| w.len() as f64).sum::<f64>() / n_words;
     let q_word_diversity = unique.len() as f64 / n_words;
@@ -399,32 +403,31 @@ fn compute_volatility(history: &[PriceTick], hours: usize) -> f64 {
     variance.sqrt()
 }
 
-/// Compute RSI on 0-1 scale, time-weighted by the duration each price persisted.
+/// Compute RSI on a 0-1 scale as an unweighted mean of gains/losses over the last
+/// `period` deltas (matches training — scripts/fetch_data.py::_compute_rsi).
 fn compute_rsi(history: &[PriceTick], period: usize) -> f64 {
     if history.len() < period + 1 {
         return 0.5;
     }
     let recent = &history[history.len() - period - 1..];
+    // Unweighted mean of gains/losses over the last `period` deltas — must match
+    // training (scripts/fetch_data.py::_compute_rsi). A time-weighted variant here
+    // would diverge from what the model trained on (train/serve skew).
+    let n = (recent.len() - 1) as f64;
     let mut gains = 0.0;
     let mut losses = 0.0;
-    let mut total_time = 0.0;
 
     for w in recent.windows(2) {
         let delta = w[1].p - w[0].p;
-        let dt = (w[1].t - w[0].t).max(1) as f64;
-        total_time += dt;
         if delta > 0.0 {
-            gains += delta * dt;
+            gains += delta;
         } else {
-            losses -= delta * dt;
+            losses -= delta;
         }
     }
 
-    if total_time == 0.0 {
-        return 0.5;
-    }
-    let avg_gain = gains / total_time;
-    let avg_loss = losses / total_time;
+    let avg_gain = gains / n;
+    let avg_loss = losses / n;
 
     if avg_loss == 0.0 {
         return 1.0;

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -297,7 +297,9 @@ def _extract_snapshot(prices: np.ndarray, timestamps: np.ndarray,
         "momentum_24h": momentum_24h,
         "volatility_24h": volatility,
         "rsi": rsi,
-        "volume": market.get("volume_24h", volume),  # prefer 24h volume over total
+        # Use TOTAL volume (not 24h) so log_volume matches the live feature
+        # (features.rs uses market.volume_num, the total) — train/serve alignment.
+        "volume": volume,
         "liquidity": liquidity,
         "days_to_expiry": days_to_expiry,
         "days_since_created": days_since_created,
@@ -305,8 +307,13 @@ def _extract_snapshot(prices: np.ndarray, timestamps: np.ndarray,
         "category": combined,
         "question": market.get("question", ""),
         # Gamma API price changes
-        "price_change_1d": market.get("one_day_price_change", momentum_24h),
-        "price_change_1w": market.get("one_week_price_change", 0.0),
+        # Settled-delta leak: for CLOSED markets these Gamma fields are
+        # near-resolution deltas that encode the outcome (inflated historical
+        # metrics). Neutralized to 0 at train AND serve so the model learns no
+        # weight on them. See ADR 011 / the honest backtest. (Feature slot kept
+        # to avoid a schema change; a future cleanup can drop it entirely.)
+        "price_change_1d": 0.0,
+        "price_change_1w": 0.0,
         # Label
         "outcome_yes": market["outcome_yes"],
         # Metadata

--- a/scripts/serve_model.py
+++ b/scripts/serve_model.py
@@ -124,6 +124,9 @@ RETRAIN_MARKETS = int(os.environ.get("RETRAIN_MARKETS", "3000"))
 DATABASE_URL = os.environ.get("DATABASE_URL")
 # Trigger warm-start retrain after this many new resolved bets accumulate
 WARMSTART_TRIGGER_N = int(os.environ.get("WARMSTART_TRIGGER_N", "10"))
+# Warm-start fetches fewer markets than a full retrain (faster), then trains the
+# same calibrated ensemble on that + recent resolved bets.
+WARMSTART_MARKETS = int(os.environ.get("WARMSTART_MARKETS", "500"))
 
 # Feature names — must stay in sync with MarketFeatures::NAMES in src/model/features.rs
 # v4: re-added is_sports — was zero SHAP because training data had no sports.
@@ -234,8 +237,13 @@ def model_age_hours() -> float | None:
     return (time.time() - MODEL_PATH.stat().st_mtime) / 3600
 
 
-def _run_retrain():
-    """Full cold retrain: fetch N markets + train from scratch, then reload."""
+def _run_training(markets: int, kind: str):
+    """Fetch `markets` markets + merge our own resolved bets (via --db), train the
+    full calibrated ensemble, dump ensemble.joblib (THE served model), then reload.
+
+    Shared by the full retrain and warm-start — both must produce the calibrated
+    ensemble.joblib that the sidecar serves (an earlier warm-start wrote only
+    xgb_model.json, which is never loaded, and skipped calibration entirely)."""
     _retrain.status = RetrainStatus.running
     _retrain.started_at = datetime.now(timezone.utc).isoformat()
     _retrain.finished_at = None
@@ -243,10 +251,10 @@ def _run_retrain():
     _retrain.step = "fetch"
 
     try:
-        log.info("retrain.fetch_start: markets=%d", RETRAIN_MARKETS)
+        log.info("%s.fetch_start: markets=%d", kind, markets)
         fetch_args = [
             sys.executable, "fetch_data.py",
-            "--markets", str(RETRAIN_MARKETS),
+            "--markets", str(markets),
             "--output", f"{MODEL_DIR}/training_data.json",
         ]
         if DATABASE_URL:
@@ -254,7 +262,7 @@ def _run_retrain():
         subprocess.run(fetch_args, check=True, capture_output=True, text=True)
 
         _retrain.step = "train"
-        log.info("retrain.train_start")
+        log.info("%s.train_start", kind)
         subprocess.run(
             [sys.executable, "train_model.py",
              "--input", f"{MODEL_DIR}/training_data.json",
@@ -266,122 +274,39 @@ def _run_retrain():
         load_model()
         _retrain.status = RetrainStatus.success
         _retrain.step = None
-        log.info("retrain.complete")
+        log.info("%s.complete", kind)
     except subprocess.CalledProcessError as e:
         _retrain.status = RetrainStatus.failed
         _retrain.error = e.stderr[-500:] if e.stderr else str(e)
-        log.error("retrain.failed: %s", _retrain.error)
+        log.error("%s.failed: %s", kind, _retrain.error)
     except Exception as e:
         _retrain.status = RetrainStatus.failed
         _retrain.error = str(e)
-        log.error("retrain.failed: %s", e)
+        log.error("%s.failed: %s", kind, e)
     finally:
         _retrain.finished_at = datetime.now(timezone.utc).isoformat()
 
 
+def _run_retrain():
+    """Full cold retrain: fetch RETRAIN_MARKETS markets + train from scratch."""
+    _run_training(RETRAIN_MARKETS, "retrain")
+
+
 def _run_warmstart():
-    """Warm-start retrain: add XGBoost trees on top of existing model using stored bet_features.
+    """Warm-start: a lighter, faster retrain — fetch WARMSTART_MARKETS markets
+    (fewer than a full retrain) + merge recent resolved bets, then train the full
+    CALIBRATED ensemble and dump ensemble.joblib (the served model).
 
-    No API calls — reads exact feature vectors from DB. Takes seconds.
-    Triggered automatically every WARMSTART_TRIGGER_N resolved bets.
-    """
+    Shares the training path with the full retrain via _run_training, so it can
+    never again diverge into writing a file the sidecar doesn't serve or skipping
+    calibration (the previous "add 50 trees to xgb_model.json" implementation did
+    both — it was a no-op on live predictions)."""
     if not DATABASE_URL:
-        log.warning("warmstart.skip", reason="DATABASE_URL not set")
+        # Warm-start's point is to fold in our own resolved bets; without a DB
+        # it would just refetch markets for nothing. Skip.
+        log.info("warmstart.skip", reason="no DATABASE_URL; no resolved-bet feedback to add")
         return
-
-    try:
-        import psycopg2
-    except ImportError:
-        log.warning("warmstart.skip", reason="psycopg2 not installed")
-        return
-
-    try:
-        import xgboost as xgb
-        from sklearn.calibration import CalibratedClassifierCV
-        from sklearn.preprocessing import RobustScaler
-    except ImportError as e:
-        log.warning("warmstart.skip", reason=str(e))
-        return
-
-    log.info("warmstart.start", trigger_n=WARMSTART_TRIGGER_N)
-
-    try:
-        conn = psycopg2.connect(DATABASE_URL)
-        cur = conn.cursor()
-        cur.execute("""
-            SELECT bf.features, b.won, b.side
-            FROM bet_features bf
-            JOIN bets b ON b.id = bf.bet_id
-            WHERE b.resolved = TRUE AND b.won IS NOT NULL
-            ORDER BY b.resolved_at DESC
-        """)
-        rows = cur.fetchall()
-        conn.close()
-    except Exception as e:
-        log.error("warmstart.db_error", error=str(e))
-        return
-
-    if len(rows) < 10:
-        log.info("warmstart.skip", reason="not enough resolved bets", n=len(rows))
-        return
-
-    # Build feature matrix from stored JSONB
-    records = []
-    labels = []
-    for features_json, won, side in rows:
-        if features_json is None or won is None:
-            continue
-        row = {k: float(v) if v is not None else 0.0 for k, v in features_json.items()}
-        outcome_yes = won if side == "Yes" else not won
-        records.append(row)
-        labels.append(int(outcome_yes))
-
-    if len(records) < 10:
-        log.info("warmstart.skip", reason="not enough clean records", n=len(records))
-        return
-
-    df = pd.DataFrame(records)
-    for col in FEATURE_NAMES:
-        if col not in df.columns:
-            df[col] = 0.0
-    X = df[FEATURE_NAMES].astype(np.float64).fillna(0.0)
-    y = np.array(labels)
-
-    # Scale using existing scaler
-    if scaler is not None:
-        X_scaled = pd.DataFrame(scaler.transform(X), columns=FEATURE_NAMES)
-    else:
-        X_scaled = X
-
-    # Warm-start XGBoost: continue from existing model, add 50 trees
-    xgb_path = Path(MODEL_DIR) / "xgb_model.json"
-    if not xgb_path.exists():
-        log.warning("warmstart.skip", reason="no existing xgb_model.json")
-        return
-
-    try:
-        booster = xgb.XGBClassifier(
-            n_estimators=50,
-            learning_rate=0.03,
-            max_depth=4,
-            subsample=0.8,
-            colsample_bytree=0.8,
-            objective="binary:logistic",
-            eval_metric="logloss",
-            random_state=42,
-            n_jobs=-1,
-            verbosity=0,
-        )
-        booster.fit(X_scaled, y, xgb_model=str(xgb_path))
-        booster.save_model(str(xgb_path))
-        log.info("warmstart.xgb_updated", n_samples=len(records), trees_added=50)
-    except Exception as e:
-        log.error("warmstart.xgb_failed", error=str(e))
-        return
-
-    # Hot-reload so next predictions use the updated model
-    load_model()
-    log.info("warmstart.complete", n_samples=len(records))
+    _run_training(WARMSTART_MARKETS, "warmstart")
 
 
 def _force_retrain():
@@ -651,10 +576,20 @@ def retrain(req: RetrainRequest = RetrainRequest()):
 
 @app.post("/retrain/warmstart")
 def retrain_warmstart():
-    """Warm-start retrain on stored bet_features — no API calls, takes seconds."""
-    if _retrain.status == RetrainStatus.running:
+    """Warm-start: a lighter retrain (WARMSTART_MARKETS markets + recent resolved
+    bets) that trains the full calibrated ensemble. Takes minutes and hits the
+    API — not the old 'seconds, no API' behavior. Serialized via _retrain.lock so
+    it can't run concurrently with a full retrain (both write the same files)."""
+    if not _retrain.lock.acquire(blocking=False):
         raise HTTPException(status_code=409, detail="Retrain already in progress")
-    threading.Thread(target=_run_warmstart, daemon=True).start()
+
+    def run():
+        try:
+            _run_warmstart()
+        finally:
+            _retrain.lock.release()
+
+    threading.Thread(target=run, daemon=True).start()
     return {"status": "started", "kind": "warmstart"}
 
 


### PR DESCRIPTION
## Summary
Fixes to the ML retraining/serving pipeline. No new features — repairs broken plumbing + aligns live features to training. Takes effect on the next retrain (the schema guard refreshes the served model).

## Warm-start (was a no-op)
Previously warm-start added 50 trees to `xgb_model.json` — a file the sidecar **never loads** (it serves `ensemble.joblib`) and which **bypassed calibration**, so it had zero effect on live predictions. Now it shares `_run_training` with the full retrain: fetches `WARMSTART_MARKETS` (fewer than a full retrain) + recent resolved bets, trains the full **calibrated** ensemble, dumps `ensemble.joblib`, and is serialized under `_retrain.lock` so it can't race a full retrain. Skips cleanly when `DATABASE_URL` is unset.

## Train/serve skew (model was handicapped by seeing different features than it trained on)
- **RSI** — live now unweighted mean of gains/losses (matches `fetch_data._compute_rsi`; the old time-weighted variant diverged).
- **q_length** — char count, not bytes (matches Python `len()`).
- **log_volume** — training now uses total volume (matches live `market.volume_num`).
- **price_change_1d/1w** — settled-delta **leak** (for closed markets these Gamma deltas encode the outcome) neutralized to 0 at train + serve; feature slot kept to avoid a schema change.

## Notes
- The matching live price-history `fidelity=60` change lives in the bot PR (it's a one-liner inside `trading-bot/src/scanner/live.rs`, kept with the rest of that file).
- Export-gating (refuse to ship a worse-than-market model) is intentionally **not** in this PR — it needs the leak-free market-grouped eval and is tracked separately.

## Testing
`cargo build/clippy` green; `serve_model.py`/`fetch_data.py` compile. Validated against the honest backtest harness (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)