### PR TITLE
Telegram/copy-bot features, portfolio accounting, analytics + ops fixes

### DIFF
--- a/analysis/performance_queries.sql
+++ b/analysis/performance_queries.sql
@@ -19,7 +19,7 @@ SELECT
   ROUND(SUM(fee_paid)::numeric, 2)                  AS total_fees,
   ROUND(AVG(pnl) FILTER (WHERE resolved)::numeric, 3) AS avg_pnl_per_bet,
   ROUND((SUM(pnl) FILTER (WHERE resolved)
-    / NULLIF(SUM(cost) FILTER (WHERE resolved), 0) * 100)::numeric, 2) AS roi_pct
+    / NULLIF(SUM(cost + COALESCE(fee_paid, 0)) FILTER (WHERE resolved), 0) * 100)::numeric, 2) AS roi_pct
 FROM bets;
 
 -- ============================================================
@@ -327,7 +327,7 @@ SELECT
   ROUND(SUM(b.pnl) FILTER (WHERE b.resolved)::numeric, 2) AS pnl
 FROM bets b
 JOIN followed_traders ft
-  ON b.copy_ref->>'proxy_wallet' = ft.proxy_wallet
+  ON b.copy_ref->>'wallet' = ft.proxy_wallet
 WHERE b.source = 'copy_trade'
 GROUP BY ft.username
 ORDER BY pnl DESC;

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -503,12 +503,49 @@ pub struct TraderRow {
     pub wallet_short: String,
     pub rank: Option<i32>,
     pub poly_pnl: Option<f64>,
+    pub poly_pnl_month: Option<f64>,
     pub bankroll: f64,
     pub starting_bankroll: f64,
     pub wins: usize,
     pub losses: usize,
     pub pnl: f64,
     pub open: usize,
+}
+
+/// A single subscriber row for the owner-only `/subscribers` view.
+pub struct SubscriberRow {
+    pub chat_id: String,
+    pub username: Option<String>,
+    pub first_name: Option<String>,
+    pub active: bool,
+    pub last_seen: chrono::DateTime<chrono::Utc>,
+}
+
+/// Render the owner-only `/subscribers` list (active first).
+pub fn format_subscribers(rows: &[SubscriberRow]) -> String {
+    if rows.is_empty() {
+        return "👥 *Subscribers*\n\nNo subscribers yet.".to_string();
+    }
+    let active = rows.iter().filter(|r| r.active).count();
+    let mut lines = vec![format!(
+        "👥 *Subscribers* ({active} active / {} total)\n",
+        rows.len()
+    )];
+    for r in rows {
+        let name = escape_markdown(
+            r.username
+                .as_deref()
+                .or(r.first_name.as_deref())
+                .unwrap_or("—"),
+        );
+        let status = if r.active { "" } else { " · inactive" };
+        lines.push(format!(
+            "• {name} — `{}` · seen {}{status}",
+            r.chat_id,
+            r.last_seen.format("%Y-%m-%d")
+        ));
+    }
+    lines.join("\n")
 }
 
 /// Render the `/traders` message from a slice of rows.
@@ -527,10 +564,14 @@ pub fn format_traders(traders: &[TraderRow]) -> String {
             .poly_pnl
             .map(|p| format!("${:.0}k", p / 1000.0))
             .unwrap_or_else(|| "—".into());
+        let poly_pnl_month = t
+            .poly_pnl_month
+            .map(|p| format!("${:.0}k", p / 1000.0))
+            .unwrap_or_else(|| "—".into());
         lines.push(format!(
             "👤 {name}\n\
              \u{00a0}\u{00a0}🔑 `{wallet}`\n\
-             \u{00a0}\u{00a0}🏆 Rank: {rank} | Poly PnL: {poly_pnl}\n\
+             \u{00a0}\u{00a0}🏆 Rank: {rank} | Poly PnL: {poly_pnl} (1M: {poly_pnl_month})\n\
              \u{00a0}\u{00a0}💰 Bankroll: `€{bankroll:.2}`\n\
              \u{00a0}\u{00a0}📊 Record: {wins}W/{losses}L ({pnl:+.2}€)\n\
              \u{00a0}\u{00a0}🔓 Open: {open}",
@@ -601,6 +642,31 @@ mod tests {
     use chrono::Utc;
 
     #[test]
+    fn test_format_subscribers_empty_and_counts() {
+        assert!(format_subscribers(&[]).contains("No subscribers"));
+        let rows = vec![
+            SubscriberRow {
+                chat_id: "111".into(),
+                username: Some("alice".into()),
+                first_name: Some("Alice".into()),
+                active: true,
+                last_seen: Utc::now(),
+            },
+            SubscriberRow {
+                chat_id: "222".into(),
+                username: None,
+                first_name: Some("Bob".into()),
+                active: false,
+                last_seen: Utc::now(),
+            },
+        ];
+        let out = format_subscribers(&rows);
+        assert!(out.contains("1 active / 2 total"));
+        assert!(out.contains("alice") && out.contains("`111`"));
+        assert!(out.contains("Bob") && out.contains("inactive"));
+    }
+
+    #[test]
     fn test_trader_row_has_starting_bankroll() {
         let row = TraderRow {
             name: "alice".to_string(),
@@ -608,6 +674,7 @@ mod tests {
             wallet_short: "0xabc123".to_string(),
             rank: None,
             poly_pnl: None,
+            poly_pnl_month: None,
             bankroll: 500.0,
             starting_bankroll: 400.0,
             wins: 3,
@@ -912,6 +979,7 @@ mod tests {
             wallet_short: format!("0x{name}"),
             rank: None,
             poly_pnl: None,
+            poly_pnl_month: None,
             bankroll,
             starting_bankroll: starting,
             wins,

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -11,6 +11,16 @@ use anyhow::{Context, Result};
 use super::portfolio::Bet;
 use super::postgres::{FollowedTrader, FollowedTraderRow, NewCopyTradeEvent, PgPortfolio};
 
+/// Leaderboard stats to write for a followed trader — grouped to avoid a long
+/// positional argument list on `update_trader_stats`.
+pub struct TraderStatsUpdate<'a> {
+    pub rank: Option<i32>,
+    pub pnl: Option<f64>,
+    pub pnl_month: Option<f64>,
+    pub volume: Option<f64>,
+    pub username: Option<&'a str>,
+}
+
 impl PgPortfolio {
     /// Upsert a trader into `followed_traders`.
     ///
@@ -91,11 +101,7 @@ impl PgPortfolio {
     pub async fn update_trader_stats(
         &self,
         wallet: &str,
-        rank: Option<i32>,
-        pnl: Option<f64>,
-        pnl_month: Option<f64>,
-        volume: Option<f64>,
-        username: Option<&str>,
+        stats: TraderStatsUpdate<'_>,
     ) -> Result<()> {
         sqlx::query(
             "UPDATE followed_traders SET \
@@ -106,11 +112,11 @@ impl PgPortfolio {
                username  = COALESCE($5, username) \
              WHERE proxy_wallet = $6",
         )
-        .bind(rank)
-        .bind(pnl)
-        .bind(pnl_month)
-        .bind(volume)
-        .bind(username)
+        .bind(stats.rank)
+        .bind(stats.pnl)
+        .bind(stats.pnl_month)
+        .bind(stats.volume)
+        .bind(stats.username)
         .bind(wallet)
         .execute(&self.pool)
         .await

--- a/common/src/storage/copy_trade.rs
+++ b/common/src/storage/copy_trade.rs
@@ -52,7 +52,7 @@ impl PgPortfolio {
     /// Return all traders with `active = true`.
     pub async fn get_active_traders(&self) -> Result<Vec<FollowedTrader>> {
         let rows: Vec<FollowedTraderRow> = sqlx::query_as(
-            "SELECT id, proxy_wallet, username, source, rank, pnl, volume, win_rate, \
+            "SELECT id, proxy_wallet, username, source, rank, pnl, pnl_month, volume, win_rate, \
                     added_at, last_checked_at, active \
              FROM followed_traders \
              WHERE active = TRUE \
@@ -93,19 +93,22 @@ impl PgPortfolio {
         wallet: &str,
         rank: Option<i32>,
         pnl: Option<f64>,
+        pnl_month: Option<f64>,
         volume: Option<f64>,
         username: Option<&str>,
     ) -> Result<()> {
         sqlx::query(
             "UPDATE followed_traders SET \
-               rank     = $1, \
-               pnl      = $2, \
-               volume   = $3, \
-               username = COALESCE($4, username) \
-             WHERE proxy_wallet = $5",
+               rank      = $1, \
+               pnl       = $2, \
+               pnl_month = $3, \
+               volume    = $4, \
+               username  = COALESCE($5, username) \
+             WHERE proxy_wallet = $6",
         )
         .bind(rank)
         .bind(pnl)
+        .bind(pnl_month)
         .bind(volume)
         .bind(username)
         .bind(wallet)
@@ -173,7 +176,7 @@ impl PgPortfolio {
     /// Look up a single followed trader by wallet address.
     pub async fn get_trader_by_wallet(&self, wallet: &str) -> Result<Option<FollowedTrader>> {
         let row: Option<FollowedTraderRow> = sqlx::query_as(
-            "SELECT id, proxy_wallet, username, source, rank, pnl, volume, win_rate, \
+            "SELECT id, proxy_wallet, username, source, rank, pnl, pnl_month, volume, win_rate, \
                     added_at, last_checked_at, active \
              FROM followed_traders WHERE proxy_wallet = $1",
         )
@@ -229,6 +232,7 @@ impl PgPortfolio {
                 wallet_short: short.to_string(),
                 rank: t.rank,
                 poly_pnl: t.pnl,
+                poly_pnl_month: t.pnl_month,
                 bankroll,
                 starting_bankroll,
                 wins,

--- a/common/src/storage/postgres.rs
+++ b/common/src/storage/postgres.rs
@@ -233,36 +233,95 @@ impl PgPortfolio {
         Ok(())
     }
 
-    /// Upsert a Telegram user (tracks who interacts with the bot).
+    /// Upsert a Telegram user for a specific bot. Returns `true` if a new row
+    /// was inserted (first time this user joined this bot).
     pub async fn upsert_telegram_user(
         &self,
+        bot: &str,
         chat_id: &str,
         username: Option<&str>,
         first_name: Option<&str>,
-    ) -> Result<()> {
-        sqlx::query(
-            "INSERT INTO telegram_users (chat_id, username, first_name, last_seen) \
-             VALUES ($1, $2, $3, NOW()) \
-             ON CONFLICT (chat_id) DO UPDATE SET \
+    ) -> Result<bool> {
+        // `xmax = 0` is true only for a freshly INSERTed row (no prior version),
+        // false when the ON CONFLICT UPDATE branch ran.
+        // `active = TRUE` in the UPDATE branch auto-reactivates a returning user
+        // who had previously been pruned.
+        let row: (bool,) = sqlx::query_as(
+            "INSERT INTO telegram_users (bot, chat_id, username, first_name, last_seen) \
+             VALUES ($1, $2, $3, $4, NOW()) \
+             ON CONFLICT (bot, chat_id) DO UPDATE SET \
                username = COALESCE(EXCLUDED.username, telegram_users.username), \
                first_name = COALESCE(EXCLUDED.first_name, telegram_users.first_name), \
-               last_seen = NOW()",
+               active = TRUE, \
+               last_seen = NOW() \
+             RETURNING (xmax = 0) AS inserted",
         )
+        .bind(bot)
         .bind(chat_id)
         .bind(username)
         .bind(first_name)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
         .await?;
-        Ok(())
+        Ok(row.0)
     }
 
-    /// Get subscriber chat IDs with their usernames for logging.
-    pub async fn telegram_subscribers(&self) -> Result<Vec<(String, Option<String>)>> {
-        let rows: Vec<(String, Option<String>)> =
-            sqlx::query_as("SELECT chat_id, username FROM telegram_users")
-                .fetch_all(&self.pool)
-                .await?;
+    /// Full subscriber detail for the owner's `/subscribers` view (this bot only),
+    /// active first then most-recently-seen.
+    pub async fn list_subscribers(&self, bot: &str) -> Result<Vec<crate::format::SubscriberRow>> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            chat_id: String,
+            username: Option<String>,
+            first_name: Option<String>,
+            active: bool,
+            last_seen: DateTime<Utc>,
+        }
+        let rows: Vec<Row> = sqlx::query_as(
+            "SELECT chat_id, username, first_name, active, last_seen \
+             FROM telegram_users WHERE bot = $1 \
+             ORDER BY active DESC, last_seen DESC",
+        )
+        .bind(bot)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| crate::format::SubscriberRow {
+                chat_id: r.chat_id,
+                username: r.username,
+                first_name: r.first_name,
+                active: r.active,
+                last_seen: r.last_seen,
+            })
+            .collect())
+    }
+
+    /// Active subscriber chat IDs (with usernames for logging) for a specific bot.
+    pub async fn telegram_subscribers(&self, bot: &str) -> Result<Vec<(String, Option<String>)>> {
+        let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+            "SELECT chat_id, username FROM telegram_users WHERE bot = $1 AND active",
+        )
+        .bind(bot)
+        .fetch_all(&self.pool)
+        .await?;
         Ok(rows)
+    }
+
+    /// Soft-deactivate subscribers of `bot` that permanently failed to receive
+    /// messages (blocked the bot / chat not found). Returns rows affected.
+    pub async fn deactivate_telegram_users(&self, bot: &str, chat_ids: &[String]) -> Result<u64> {
+        if chat_ids.is_empty() {
+            return Ok(0);
+        }
+        let res = sqlx::query(
+            "UPDATE telegram_users SET active = FALSE, blocked_at = NOW() \
+             WHERE bot = $1 AND chat_id = ANY($2)",
+        )
+        .bind(bot)
+        .bind(chat_ids)
+        .execute(&self.pool)
+        .await?;
+        Ok(res.rows_affected())
     }
 
     /// Build a stats summary string for /stats command.
@@ -641,6 +700,16 @@ impl PgPortfolio {
 
     pub async fn upsert_f64_pub(&self, key: &str, val: f64) -> Result<()> {
         self.upsert_f64(key, val).await
+    }
+
+    /// Read a text metadata value from the `portfolio` kv table (empty string if absent).
+    pub async fn get_text_pub(&self, key: &str) -> Result<String> {
+        self.get_text(key).await
+    }
+
+    /// Insert-or-update a text metadata value in the `portfolio` kv table.
+    pub async fn upsert_text_pub(&self, key: &str, val: &str) -> Result<()> {
+        self.upsert_text(key, val).await
     }
 
     async fn upsert_f64(&self, key: &str, val: f64) -> Result<()> {
@@ -1039,11 +1108,15 @@ impl PgPortfolio {
             .execute(&mut *tx)
             .await?;
 
-        // Atomically credit global bankroll
-        sqlx::query("UPDATE portfolio SET value_f64 = value_f64 + $1 WHERE key = 'bankroll'")
-            .bind(net_payout)
-            .execute(&mut *tx)
-            .await?;
+        // Credit the global bankroll ONLY for ML strategies. Copy-trade bets are
+        // fully separate from the ML bot: place_copy_bet never debits global, so
+        // crediting it here would inflate it (this was the source of the drift).
+        if !strategy.starts_with("copy:") {
+            sqlx::query("UPDATE portfolio SET value_f64 = value_f64 + $1 WHERE key = 'bankroll'")
+                .bind(net_payout)
+                .execute(&mut *tx)
+                .await?;
+        }
 
         // Read the updated strategy bankroll within the transaction for the return value
         let updated_strat_bankroll: Option<(Option<f64>,)> =
@@ -1172,11 +1245,14 @@ impl PgPortfolio {
             .execute(&mut *tx)
             .await?;
 
-        // Atomically credit global bankroll
-        sqlx::query("UPDATE portfolio SET value_f64 = value_f64 + $1 WHERE key = 'bankroll'")
-            .bind(net_payout)
-            .execute(&mut *tx)
-            .await?;
+        // Credit the global bankroll ONLY for ML strategies (copy is fully
+        // separate — place_copy_bet never debits global). See resolve_bet.
+        if !r.strategy.starts_with("copy:") {
+            sqlx::query("UPDATE portfolio SET value_f64 = value_f64 + $1 WHERE key = 'bankroll'")
+                .bind(net_payout)
+                .execute(&mut *tx)
+                .await?;
+        }
 
         // Read the updated strategy bankroll within the transaction for the return value
         let updated_strat_bankroll: Option<(Option<f64>,)> =
@@ -1626,6 +1702,7 @@ pub struct FollowedTrader {
     pub source: String,
     pub rank: Option<i32>,
     pub pnl: Option<f64>,
+    pub pnl_month: Option<f64>,
     pub volume: Option<f64>,
     pub win_rate: Option<f64>,
     pub added_at: DateTime<Utc>,
@@ -1672,6 +1749,7 @@ pub(super) struct FollowedTraderRow {
     source: String,
     rank: Option<i32>,
     pnl: Option<f64>,
+    pnl_month: Option<f64>,
     volume: Option<f64>,
     win_rate: Option<f64>,
     added_at: DateTime<Utc>,
@@ -1688,6 +1766,7 @@ impl FollowedTraderRow {
             source: self.source,
             rank: self.rank,
             pnl: self.pnl,
+            pnl_month: self.pnl_month,
             volume: self.volume,
             win_rate: self.win_rate,
             added_at: self.added_at,

--- a/common/src/telegram/notifier.rs
+++ b/common/src/telegram/notifier.rs
@@ -49,6 +49,14 @@ impl BotKind {
     }
 }
 
+/// Result of a broadcast: chats we reached, and chats that permanently failed
+/// (to be deactivated by the prune worker). Transient failures are omitted.
+#[derive(Debug, Default)]
+pub struct BroadcastResponse {
+    pub sent: Vec<String>,
+    pub failed: Vec<String>,
+}
+
 /// Telegram sendMessage request body.
 #[derive(serde::Serialize)]
 struct SendMessagePayload<'a> {
@@ -92,33 +100,35 @@ impl TelegramNotifier {
         self.send_to(&self.chat_id, message).await
     }
 
-    /// Send to owner + all subscribers. Returns chat_ids that PERMANENTLY failed
-    /// (blocked / chat not found) so the caller can deactivate them.
+    /// Send to owner + all subscribers. Pure send: reports which chats succeeded
+    /// and which PERMANENTLY failed (blocked / chat not found). It does NOT touch
+    /// the DB — the caller routes `failed` to the prune worker. Transient failures
+    /// (rate-limit / server error) are kept (not reported as failed) and retried
+    /// on the next broadcast.
     pub async fn broadcast(
         &self,
         subscribers: &[(String, Option<String>)],
         message: &str,
-    ) -> Vec<String> {
+    ) -> BroadcastResponse {
         let _ = self.send(message).await; // owner
-        let mut pruned = Vec::new();
+        let mut resp = BroadcastResponse::default();
         for (id, username) in subscribers {
             if id == &self.chat_id {
                 continue;
             }
             let label = username.as_deref().unwrap_or("unknown");
             match self.send_to_classified(id, message).await {
-                Ok(()) => {}
+                Ok(()) => resp.sent.push(id.clone()),
                 Err(SendError::Permanent(body)) => {
-                    tracing::info!(chat_id = %id, username = label, "Pruning unreachable subscriber");
-                    tracing::debug!(chat_id = %id, body = %body, "Permanent Telegram failure");
-                    pruned.push(id.clone());
+                    tracing::debug!(chat_id = %id, username = label, body = %body, "Permanent Telegram failure");
+                    resp.failed.push(id.clone());
                 }
                 Err(SendError::Transient(body)) => {
                     tracing::warn!(chat_id = %id, username = label, err = %body, "Transient send failure (kept)");
                 }
             }
         }
-        pruned
+        resp
     }
 
     /// Send to one chat, returning a typed error that says whether the failure

--- a/common/src/telegram/notifier.rs
+++ b/common/src/telegram/notifier.rs
@@ -2,22 +2,59 @@ use anyhow::{Context, Result};
 use reqwest::Client;
 use std::sync::atomic::{AtomicI64, Ordering};
 
+/// Outcome of a failed Telegram send, used to decide whether to prune a subscriber.
+#[derive(Debug)]
+pub enum SendError {
+    /// The chat is gone for this bot (blocked / not found / deactivated) — prune it.
+    Permanent(String),
+    /// Temporary failure (rate limit, server error, network) — keep the subscriber.
+    Transient(String),
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SendError::Permanent(m) => write!(f, "permanent: {m}"),
+            SendError::Transient(m) => write!(f, "transient: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SendError {}
+
+/// Classify a Telegram sendMessage failure. `error_code` is Telegram's numeric
+/// code (None for a transport/network error). 400 (chat not found) and 403
+/// (bot blocked / user deactivated) mean the chat is permanently unreachable.
+pub fn classify_telegram_error(error_code: Option<i64>, body: &str) -> SendError {
+    match error_code {
+        Some(400) | Some(403) => SendError::Permanent(body.to_string()),
+        _ => SendError::Transient(body.to_string()),
+    }
+}
+
 pub struct TelegramNotifier {
     client: Client,
     bot_token: String,
     chat_id: String,
+    bot_kind: String,
     /// Last processed update_id for polling
     last_update_id: AtomicI64,
 }
 
 impl TelegramNotifier {
-    pub fn new(bot_token: &str, chat_id: &str) -> Self {
+    pub fn new(bot_token: &str, chat_id: &str, bot_kind: &str) -> Self {
         Self {
             client: Client::new(),
             bot_token: bot_token.to_string(),
             chat_id: chat_id.to_string(),
+            bot_kind: bot_kind.to_string(),
             last_update_id: AtomicI64::new(0),
         }
+    }
+
+    /// The bot identity ("trading" or "copy") used to scope subscribers.
+    pub fn bot_kind(&self) -> &str {
+        &self.bot_kind
     }
 
     /// Check if a chat_id belongs to the bot owner.
@@ -29,22 +66,77 @@ impl TelegramNotifier {
         self.send_to(&self.chat_id, message).await
     }
 
-    /// Send to owner + all subscribers (deduped).
-    pub async fn broadcast(&self, subscribers: &[(String, Option<String>)], message: &str) {
-        let recipients = 1 + subscribers
-            .iter()
-            .filter(|(id, _)| id != &self.chat_id)
-            .count();
-        let _ = self.send(message).await;
+    /// Send to owner + all subscribers. Returns chat_ids that PERMANENTLY failed
+    /// (blocked / chat not found) so the caller can deactivate them.
+    pub async fn broadcast(
+        &self,
+        subscribers: &[(String, Option<String>)],
+        message: &str,
+    ) -> Vec<String> {
+        let _ = self.send(message).await; // owner
+        let mut pruned = Vec::new();
         for (id, username) in subscribers {
-            if id != &self.chat_id {
-                let label = username.as_deref().unwrap_or("unknown");
-                if let Err(e) = self.send_to(id, message).await {
-                    tracing::warn!(chat_id = %id, username = label, err = %e, "Failed to send to subscriber");
+            if id == &self.chat_id {
+                continue;
+            }
+            let label = username.as_deref().unwrap_or("unknown");
+            match self.send_to_classified(id, message).await {
+                Ok(()) => {}
+                Err(SendError::Permanent(body)) => {
+                    tracing::info!(chat_id = %id, username = label, "Pruning unreachable subscriber");
+                    tracing::debug!(chat_id = %id, body = %body, "Permanent Telegram failure");
+                    pruned.push(id.clone());
+                }
+                Err(SendError::Transient(body)) => {
+                    tracing::warn!(chat_id = %id, username = label, err = %body, "Transient send failure (kept)");
                 }
             }
         }
-        tracing::debug!(recipients = recipients, "Broadcast complete");
+        pruned
+    }
+
+    /// Send to one chat, returning a typed error that says whether the failure
+    /// is permanent (prune the chat) or transient (keep it).
+    async fn send_to_classified(
+        &self,
+        chat_id: &str,
+        message: &str,
+    ) -> std::result::Result<(), SendError> {
+        let url = format!("https://api.telegram.org/bot{}/sendMessage", self.bot_token);
+        let disclaimer = "_This is not financial advice. Do your own research._";
+        let footer = format!("\n\n{disclaimer}");
+        let chunks = split_message(message, 4096 - footer.len());
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let text = if i == chunks.len() - 1 {
+                format!("{chunk}{footer}")
+            } else {
+                chunk.to_string()
+            };
+            let resp = match self
+                .client
+                .post(&url)
+                .json(&serde_json::json!({
+                    "chat_id": chat_id,
+                    "text": text,
+                    "parse_mode": "Markdown",
+                    "disable_web_page_preview": true,
+                }))
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => return Err(SendError::Transient(e.to_string())),
+            };
+            if !resp.status().is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                let code = serde_json::from_str::<serde_json::Value>(&body)
+                    .ok()
+                    .and_then(|v| v["error_code"].as_i64());
+                return Err(classify_telegram_error(code, &body));
+            }
+        }
+        Ok(())
     }
 
     pub async fn send_to(&self, chat_id: &str, message: &str) -> Result<()> {
@@ -244,6 +336,41 @@ fn split_message(text: &str, max_chars: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_classify_blocked_is_permanent() {
+        let body = r#"{"ok":false,"error_code":403,"description":"Forbidden: bot was blocked by the user"}"#;
+        assert!(matches!(
+            classify_telegram_error(Some(403), body),
+            SendError::Permanent(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_chat_not_found_is_permanent() {
+        let body = r#"{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}"#;
+        assert!(matches!(
+            classify_telegram_error(Some(400), body),
+            SendError::Permanent(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_rate_limit_is_transient() {
+        let body = r#"{"ok":false,"error_code":429,"description":"Too Many Requests"}"#;
+        assert!(matches!(
+            classify_telegram_error(Some(429), body),
+            SendError::Transient(_)
+        ));
+    }
+
+    #[test]
+    fn test_classify_unknown_is_transient() {
+        assert!(matches!(
+            classify_telegram_error(None, "network error"),
+            SendError::Transient(_)
+        ));
+    }
 
     #[test]
     fn test_split_short_message_unchanged() {

--- a/common/src/telegram/notifier.rs
+++ b/common/src/telegram/notifier.rs
@@ -32,29 +32,55 @@ pub fn classify_telegram_error(error_code: Option<i64>, body: &str) -> SendError
     }
 }
 
+/// Which bot a notifier belongs to — used to scope subscribers per bot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotKind {
+    Trading,
+    Copy,
+}
+
+impl BotKind {
+    /// Storage/DB key form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BotKind::Trading => "trading",
+            BotKind::Copy => "copy",
+        }
+    }
+}
+
+/// Telegram sendMessage request body.
+#[derive(serde::Serialize)]
+struct SendMessagePayload<'a> {
+    chat_id: &'a str,
+    text: &'a str,
+    parse_mode: &'a str,
+    disable_web_page_preview: bool,
+}
+
 pub struct TelegramNotifier {
     client: Client,
     bot_token: String,
     chat_id: String,
-    bot_kind: String,
+    bot_kind: BotKind,
     /// Last processed update_id for polling
     last_update_id: AtomicI64,
 }
 
 impl TelegramNotifier {
-    pub fn new(bot_token: &str, chat_id: &str, bot_kind: &str) -> Self {
+    pub fn new(bot_token: &str, chat_id: &str, bot_kind: BotKind) -> Self {
         Self {
             client: Client::new(),
             bot_token: bot_token.to_string(),
             chat_id: chat_id.to_string(),
-            bot_kind: bot_kind.to_string(),
+            bot_kind,
             last_update_id: AtomicI64::new(0),
         }
     }
 
-    /// The bot identity ("trading" or "copy") used to scope subscribers.
+    /// The bot identity ("trading"/"copy") used to scope subscribers.
     pub fn bot_kind(&self) -> &str {
-        &self.bot_kind
+        self.bot_kind.as_str()
     }
 
     /// Check if a chat_id belongs to the bot owner.
@@ -116,12 +142,12 @@ impl TelegramNotifier {
             let resp = match self
                 .client
                 .post(&url)
-                .json(&serde_json::json!({
-                    "chat_id": chat_id,
-                    "text": text,
-                    "parse_mode": "Markdown",
-                    "disable_web_page_preview": true,
-                }))
+                .json(&SendMessagePayload {
+                    chat_id,
+                    text: &text,
+                    parse_mode: "Markdown",
+                    disable_web_page_preview: true,
+                })
                 .send()
                 .await
             {
@@ -169,12 +195,12 @@ impl TelegramNotifier {
             let resp = self
                 .client
                 .post(&url)
-                .json(&serde_json::json!({
-                    "chat_id": chat_id,
-                    "text": text,
-                    "parse_mode": parse_mode,
-                    "disable_web_page_preview": true,
-                }))
+                .json(&SendMessagePayload {
+                    chat_id,
+                    text: &text,
+                    parse_mode,
+                    disable_web_page_preview: true,
+                })
                 .send()
                 .await
                 .context("failed to send telegram message")?;

--- a/copy-trading-bot/src/config.rs
+++ b/copy-trading-bot/src/config.rs
@@ -30,6 +30,19 @@ pub struct CopyTradingConfig {
     /// Port for the Prometheus metrics HTTP endpoint.
     #[config(env = "METRICS_PORT", default = 9001)]
     pub metrics_port: u16,
+
+    // --- Daily top-traders digest (advisory) ---
+    /// Whether to broadcast the daily top-traders digest.
+    #[config(env = "DIGEST_ENABLED", default = true)]
+    pub digest_enabled: bool,
+
+    /// How many traders to include in the daily digest.
+    #[config(env = "DIGEST_TOP_N", default = 5)]
+    pub digest_top_n: usize,
+
+    /// UTC hour (0-23) at which the daily digest is sent.
+    #[config(env = "DIGEST_HOUR_UTC", default = 9)]
+    pub digest_hour_utc: u32,
 }
 
 impl CopyTradingConfig {

--- a/copy-trading-bot/src/cycles/copy_trade.rs
+++ b/copy-trading-bot/src/cycles/copy_trade.rs
@@ -1,16 +1,14 @@
 use anyhow::Result;
 
-use crate::config::CopyTradingConfig;
 use crate::data::models::{fetch_market_by_slug, fetch_yes_prices};
 use crate::format;
 use crate::live::broadcast;
 use crate::metrics;
 use crate::pricing::kelly::fractional_kelly;
-use crate::scanner::copy_trader::{CopyTraderMonitor, fetch_trader_username};
+use crate::scanner::copy_trader::fetch_trader_username;
 use crate::signal::SignalSource;
+use crate::state::AppState;
 use crate::storage::portfolio::{BetSide, CopyRef, NewBet};
-use crate::storage::postgres::PgPortfolio;
-use crate::telegram::notifier::TelegramNotifier;
 
 /// Default bankroll for a newly followed trader.
 pub const COPY_TRADER_STARTING_BANKROLL: f64 = 1000.0;
@@ -21,12 +19,10 @@ const MIN_BET: f64 = 3.0;
 /// Maximum allowed price drift from trader's entry before skipping.
 const MAX_PRICE_DRIFT: f64 = 0.05; // 5 percentage points
 
-pub async fn copy_trade_cycle(
-    portfolio: &PgPortfolio,
-    notifier: &TelegramNotifier,
-    monitor: &CopyTraderMonitor,
-    cfg: &CopyTradingConfig,
-) -> Result<()> {
+pub async fn copy_trade_cycle(state: &AppState) -> Result<()> {
+    let portfolio = state.portfolio.as_ref();
+    let monitor = state.monitor.as_ref();
+    let cfg = state.cfg.as_ref();
     let detected = monitor.detect_new_trades(portfolio).await?;
     if detected.is_empty() {
         return Ok(());
@@ -145,7 +141,7 @@ pub async fn copy_trade_cycle(
                             pnl = r.pnl,
                             bankroll = r.bankroll,
                         );
-                        broadcast(notifier, portfolio, &msg).await;
+                        broadcast(state, &msg).await;
                         tracing::info!(
                             market = %gamma_id,
                             trader = %trader_name,
@@ -392,7 +388,7 @@ pub async fn copy_trade_cycle(
                     bankroll: new_bankroll,
                     open: open_count,
                 });
-                broadcast(notifier, portfolio, &msg).await;
+                broadcast(state, &msg).await;
                 bets_placed += 1;
             }
             Err(e) => {

--- a/copy-trading-bot/src/cycles/digest.rs
+++ b/copy-trading-bot/src/cycles/digest.rs
@@ -1,0 +1,88 @@
+//! Daily top-traders digest (advisory).
+//!
+//! Once per day, at a configured UTC hour, broadcasts the month's top traders
+//! to all subscribers as *suggestions* to consider copying. This never follows
+//! anyone automatically — the reader chooses who to `/follow`.
+
+use anyhow::Result;
+use chrono::{Timelike, Utc};
+use reqwest::Client;
+
+use crate::config::CopyTradingConfig;
+use crate::scanner::copy_trader::{fetch_leaderboard, format_top_traders_digest};
+use crate::storage::postgres::PgPortfolio;
+use crate::telegram::notifier::TelegramNotifier;
+
+const LAST_DIGEST_KEY: &str = "last_digest_date";
+
+/// Pure decision: send only if the digest hasn't already gone out today AND the
+/// clock has reached the configured hour.
+pub fn should_send_digest(
+    last: Option<&str>,
+    today: &str,
+    current_hour: u32,
+    digest_hour: u32,
+) -> bool {
+    last != Some(today) && current_hour >= digest_hour
+}
+
+/// Send the daily digest if due. Best-effort: a fetch failure is logged and
+/// retried on the next tick (the date marker is only written on success).
+pub async fn maybe_send_daily_digest(
+    http: &Client,
+    portfolio: &PgPortfolio,
+    notifier: &TelegramNotifier,
+    cfg: &CopyTradingConfig,
+) -> Result<()> {
+    if !cfg.digest_enabled {
+        return Ok(());
+    }
+
+    let now = Utc::now();
+    let today = now.format("%Y-%m-%d").to_string();
+    let last = portfolio.get_text_pub(LAST_DIGEST_KEY).await?;
+    let last_opt = if last.is_empty() {
+        None
+    } else {
+        Some(last.as_str())
+    };
+
+    if !should_send_digest(last_opt, &today, now.hour(), cfg.digest_hour_utc) {
+        return Ok(());
+    }
+
+    match fetch_leaderboard(http, "MONTH").await {
+        Ok(entries) => {
+            let msg = format_top_traders_digest(&entries, cfg.digest_top_n);
+            crate::live::broadcast(notifier, portfolio, &msg).await;
+            portfolio.upsert_text_pub(LAST_DIGEST_KEY, &today).await?;
+            tracing::info!(top_n = cfg.digest_top_n, "Sent daily top-traders digest");
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, "Digest leaderboard fetch failed; will retry next tick");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_waits_for_hour() {
+        // never sent, but before the configured hour
+        assert!(!should_send_digest(None, "2026-08-23", 8, 9));
+    }
+
+    #[test]
+    fn test_sends_when_hour_reached_and_not_sent_today() {
+        assert!(should_send_digest(None, "2026-08-23", 9, 9));
+        assert!(should_send_digest(Some("2026-08-22"), "2026-08-23", 10, 9));
+    }
+
+    #[test]
+    fn test_skips_when_already_sent_today() {
+        assert!(!should_send_digest(Some("2026-08-23"), "2026-08-23", 12, 9));
+    }
+}

--- a/copy-trading-bot/src/cycles/digest.rs
+++ b/copy-trading-bot/src/cycles/digest.rs
@@ -26,16 +26,24 @@ pub fn should_send_digest(
     last != Some(today) && current_hour >= digest_hour
 }
 
+/// Whether the daily digest actually went out on this tick.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DigestOutcome {
+    Sent,
+    Skipped,
+}
+
 /// Send the daily digest if due. Best-effort: a fetch failure is logged and
 /// retried on the next tick (the date marker is only written on success).
+/// Returns whether it sent so callers/tests can tell.
 pub async fn maybe_send_daily_digest(
     http: &Client,
     portfolio: &PgPortfolio,
     notifier: &TelegramNotifier,
     cfg: &CopyTradingConfig,
-) -> Result<()> {
+) -> Result<DigestOutcome> {
     if !cfg.digest_enabled {
-        return Ok(());
+        return Ok(DigestOutcome::Skipped);
     }
 
     let now = Utc::now();
@@ -48,7 +56,7 @@ pub async fn maybe_send_daily_digest(
     };
 
     if !should_send_digest(last_opt, &today, now.hour(), cfg.digest_hour_utc) {
-        return Ok(());
+        return Ok(DigestOutcome::Skipped);
     }
 
     match fetch_leaderboard(http, "MONTH").await {
@@ -57,12 +65,13 @@ pub async fn maybe_send_daily_digest(
             crate::live::broadcast(notifier, portfolio, &msg).await;
             portfolio.upsert_text_pub(LAST_DIGEST_KEY, &today).await?;
             tracing::info!(top_n = cfg.digest_top_n, "Sent daily top-traders digest");
+            Ok(DigestOutcome::Sent)
         }
         Err(e) => {
             tracing::warn!(err = %e, "Digest leaderboard fetch failed; will retry next tick");
+            Ok(DigestOutcome::Skipped)
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/copy-trading-bot/src/cycles/digest.rs
+++ b/copy-trading-bot/src/cycles/digest.rs
@@ -6,12 +6,9 @@
 
 use anyhow::Result;
 use chrono::{Timelike, Utc};
-use reqwest::Client;
 
-use crate::config::CopyTradingConfig;
 use crate::scanner::copy_trader::{fetch_leaderboard, format_top_traders_digest};
-use crate::storage::postgres::PgPortfolio;
-use crate::telegram::notifier::TelegramNotifier;
+use crate::state::AppState;
 
 const LAST_DIGEST_KEY: &str = "last_digest_date";
 
@@ -36,12 +33,10 @@ pub enum DigestOutcome {
 /// Send the daily digest if due. Best-effort: a fetch failure is logged and
 /// retried on the next tick (the date marker is only written on success).
 /// Returns whether it sent so callers/tests can tell.
-pub async fn maybe_send_daily_digest(
-    http: &Client,
-    portfolio: &PgPortfolio,
-    notifier: &TelegramNotifier,
-    cfg: &CopyTradingConfig,
-) -> Result<DigestOutcome> {
+pub async fn maybe_send_daily_digest(state: &AppState) -> Result<DigestOutcome> {
+    let portfolio = state.portfolio.as_ref();
+    let http = &state.http;
+    let cfg = state.cfg.as_ref();
     if !cfg.digest_enabled {
         return Ok(DigestOutcome::Skipped);
     }
@@ -62,7 +57,7 @@ pub async fn maybe_send_daily_digest(
     match fetch_leaderboard(http, "MONTH").await {
         Ok(entries) => {
             let msg = format_top_traders_digest(&entries, cfg.digest_top_n);
-            crate::live::broadcast(notifier, portfolio, &msg).await;
+            crate::live::broadcast(state, &msg).await;
             portfolio.upsert_text_pub(LAST_DIGEST_KEY, &today).await?;
             tracing::info!(top_n = cfg.digest_top_n, "Sent daily top-traders digest");
             Ok(DigestOutcome::Sent)

--- a/copy-trading-bot/src/cycles/housekeeping.rs
+++ b/copy-trading-bot/src/cycles/housekeeping.rs
@@ -3,17 +3,14 @@ use std::time::Duration;
 
 use crate::data::models::GammaMarket;
 use crate::live::broadcast;
+use crate::state::AppState;
 use crate::storage::portfolio::BetSide;
-use crate::storage::postgres::PgPortfolio;
-use crate::telegram::notifier::TelegramNotifier;
 
 const GAMMA_API: &str = "https://gamma-api.polymarket.com";
 
-pub async fn housekeeping_cycle(
-    portfolio: &PgPortfolio,
-    notifier: &TelegramNotifier,
-    http: &reqwest::Client,
-) -> Result<()> {
+pub async fn housekeeping_cycle(state: &AppState) -> Result<()> {
+    let portfolio = state.portfolio.as_ref();
+    let http = &state.http;
     let open_ids = portfolio.open_copy_bet_market_ids().await?;
 
     for market_id in &open_ids {
@@ -50,7 +47,7 @@ pub async fn housekeeping_cycle(
                         losses = r.total_losses,
                         total_pnl = r.total_pnl,
                     );
-                    broadcast(notifier, portfolio, &msg).await;
+                    broadcast(state, &msg).await;
                     tracing::info!(
                         market = %market_id,
                         strategy = %r.strategy,

--- a/copy-trading-bot/src/cycles/mod.rs
+++ b/copy-trading-bot/src/cycles/mod.rs
@@ -1,4 +1,5 @@
 pub mod copy_trade;
+pub mod digest;
 pub mod housekeeping;
 
 pub use copy_trade::copy_trade_cycle;

--- a/copy-trading-bot/src/live.rs
+++ b/copy-trading-bot/src/live.rs
@@ -9,21 +9,40 @@ use crate::cycles;
 use crate::metrics;
 use crate::scanner::copy_trader::CopyTraderMonitor;
 use crate::storage::postgres::PgPortfolio;
-use crate::telegram::notifier::TelegramNotifier;
+use crate::telegram::notifier::{BotKind, TelegramNotifier};
 
-/// Broadcast a message to the owner and all active subscribers, pruning any that are gone.
+/// Broadcast a message to the owner and all active subscribers.
+///
+/// Sending and subscriber-lifecycle are separate concerns: `notifier.broadcast`
+/// only sends (and reports which chats are permanently gone); the cleanup is
+/// delegated to [`prune_unreachable`], not done inline here.
 pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, message: &str) {
-    let bot = notifier.bot_kind();
     let subs = portfolio
-        .telegram_subscribers(bot)
+        .telegram_subscribers(notifier.bot_kind())
         .await
         .unwrap_or_default();
     let pruned = notifier.broadcast(&subs, message).await;
-    if !pruned.is_empty() {
-        if let Err(e) = portfolio.deactivate_telegram_users(bot, &pruned).await {
-            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers");
-        } else {
-            tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers");
+    prune_unreachable(notifier, portfolio, &pruned).await;
+}
+
+/// Deactivate subscribers that permanently failed delivery (blocked / chat not
+/// found). Separate from [`broadcast`] so subscriber lifecycle is its own unit —
+/// it can be driven by any source of failed chat_ids (a broadcast, a cleanup job).
+pub async fn prune_unreachable(
+    notifier: &TelegramNotifier,
+    portfolio: &PgPortfolio,
+    pruned: &[String],
+) {
+    if pruned.is_empty() {
+        return;
+    }
+    match portfolio
+        .deactivate_telegram_users(notifier.bot_kind(), pruned)
+        .await
+    {
+        Ok(_) => tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers"),
+        Err(e) => {
+            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers")
         }
     }
 }
@@ -60,7 +79,7 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
     let notifier = Arc::new(TelegramNotifier::new(
         &cfg.telegram_bot_token,
         &cfg.telegram_chat_id,
-        "copy",
+        BotKind::Copy,
     ));
 
     let monitor = Arc::new(CopyTraderMonitor::new(

--- a/copy-trading-bot/src/live.rs
+++ b/copy-trading-bot/src/live.rs
@@ -4,45 +4,54 @@ use std::time::Duration;
 
 use sqlx::PgPool;
 
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+
 use crate::config::CopyTradingConfig;
 use crate::cycles;
 use crate::metrics;
 use crate::scanner::copy_trader::CopyTraderMonitor;
+use crate::state::AppState;
 use crate::storage::postgres::PgPortfolio;
 use crate::telegram::notifier::{BotKind, TelegramNotifier};
 
 /// Broadcast a message to the owner and all active subscribers.
 ///
-/// Sending and subscriber-lifecycle are separate concerns: `notifier.broadcast`
-/// only sends (and reports which chats are permanently gone); the cleanup is
-/// delegated to [`prune_unreachable`], not done inline here.
-pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, message: &str) {
-    let subs = portfolio
-        .telegram_subscribers(notifier.bot_kind())
+/// Pure send: `notifier.broadcast` reports which chats permanently failed, and we
+/// enqueue those to the prune worker via `state.fail_tx`. No DB access here —
+/// subscriber-lifecycle is the worker's job ([`run_prune_worker`]).
+pub async fn broadcast(state: &AppState, message: &str) {
+    let subs = state
+        .portfolio
+        .telegram_subscribers(state.notifier.bot_kind())
         .await
         .unwrap_or_default();
-    let pruned = notifier.broadcast(&subs, message).await;
-    prune_unreachable(notifier, portfolio, &pruned).await;
+    let resp = state.notifier.broadcast(&subs, message).await;
+    if !resp.failed.is_empty() {
+        // Non-blocking enqueue; if the worker is gone the ids are simply
+        // re-detected on the next broadcast.
+        let _ = state.fail_tx.send(resp.failed);
+    }
 }
 
-/// Deactivate subscribers that permanently failed delivery (blocked / chat not
-/// found). Separate from [`broadcast`] so subscriber lifecycle is its own unit —
-/// it can be driven by any source of failed chat_ids (a broadcast, a cleanup job).
-pub async fn prune_unreachable(
-    notifier: &TelegramNotifier,
-    portfolio: &PgPortfolio,
-    pruned: &[String],
+/// Prune worker: drains permanently-failed chat_ids from the in-memory queue and
+/// deactivates them. Runs as its own task, fully separate from broadcasting.
+pub async fn run_prune_worker(
+    portfolio: Arc<PgPortfolio>,
+    notifier: Arc<TelegramNotifier>,
+    mut rx: UnboundedReceiver<Vec<String>>,
 ) {
-    if pruned.is_empty() {
-        return;
-    }
-    match portfolio
-        .deactivate_telegram_users(notifier.bot_kind(), pruned)
-        .await
-    {
-        Ok(_) => tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers"),
-        Err(e) => {
-            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers")
+    while let Some(ids) = rx.recv().await {
+        if ids.is_empty() {
+            continue;
+        }
+        match portfolio
+            .deactivate_telegram_users(notifier.bot_kind(), &ids)
+            .await
+        {
+            Ok(_) => tracing::info!(count = ids.len(), "Deactivated unreachable subscribers"),
+            Err(e) => {
+                tracing::warn!(err = %e, count = ids.len(), "Failed to deactivate pruned subscribers")
+            }
         }
     }
 }
@@ -97,22 +106,38 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
         ))
         .await;
 
-    // Spawn Telegram command polling loop
-    let cmd_portfolio = Arc::clone(&portfolio);
-    let cmd_notifier = Arc::clone(&notifier);
-    let cmd_cfg = Arc::clone(&cfg);
-    let cmd_monitor = Arc::clone(&monitor);
-    let cmd_http = reqwest::Client::builder()
+    // Shared state + in-memory prune queue.
+    let (fail_tx, fail_rx) = mpsc::unbounded_channel::<Vec<String>>();
+    let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()
-        .expect("failed to build command HTTP client");
+        .expect("failed to build HTTP client");
+    let state = Arc::new(AppState {
+        portfolio: Arc::clone(&portfolio),
+        notifier: Arc::clone(&notifier),
+        monitor: Arc::clone(&monitor),
+        cfg: Arc::clone(&cfg),
+        http,
+        fail_tx,
+    });
+
+    // Prune worker — deactivates permanently-failed subscribers off the queue.
+    tokio::spawn(run_prune_worker(
+        Arc::clone(&portfolio),
+        Arc::clone(&notifier),
+        fail_rx,
+    ));
+
+    // Telegram command polling loop
+    let cmd_state = Arc::clone(&state);
     let command_loop = tokio::spawn(async move {
         loop {
-            let commands = cmd_notifier.poll_commands().await;
+            let commands = cmd_state.notifier.poll_commands().await;
             for (chat_id, cmd, username, first_name, full_text) in &commands {
-                match cmd_portfolio
+                match cmd_state
+                    .portfolio
                     .upsert_telegram_user(
-                        cmd_notifier.bot_kind(),
+                        cmd_state.notifier.bot_kind(),
                         chat_id,
                         username.as_deref(),
                         first_name.as_deref(),
@@ -122,7 +147,8 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
                     Ok(true) => {
                         let uname = username.as_deref().unwrap_or("—");
                         let fname = first_name.as_deref().unwrap_or("—");
-                        let _ = cmd_notifier
+                        let _ = cmd_state
+                            .notifier
                             .send(&format!(
                                 "🆕 *New user joined*\n\n\
                                  👤 {fname} (@{uname})\n\
@@ -140,15 +166,11 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
                     chat_id,
                     full_text,
                     first_name.as_deref(),
-                    &cmd_portfolio,
-                    &cmd_notifier,
-                    &cmd_monitor,
-                    &cmd_http,
-                    &cmd_cfg,
+                    &cmd_state,
                 )
                 .await;
 
-                if let Err(e) = cmd_notifier.send_to(chat_id, &reply).await {
+                if let Err(e) = cmd_state.notifier.send_to(chat_id, &reply).await {
                     tracing::warn!(err = %e, chat_id = chat_id, "Failed to reply to command");
                 }
             }
@@ -157,43 +179,27 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
     });
 
     // Copy trade main loop
-    let ct_portfolio = Arc::clone(&portfolio);
-    let ct_notifier = Arc::clone(&notifier);
-    let ct_monitor = Arc::clone(&monitor);
-    let ct_cfg = Arc::clone(&cfg);
+    let ct_state = Arc::clone(&state);
     let copy_trade_loop = tokio::spawn(async move {
         loop {
-            if let Err(e) =
-                cycles::copy_trade_cycle(&ct_portfolio, &ct_notifier, &ct_monitor, &ct_cfg).await
-            {
+            if let Err(e) = cycles::copy_trade_cycle(&ct_state).await {
                 tracing::error!(err = %e, "Copy trade cycle failed");
             }
-            tokio::time::sleep(Duration::from_secs(ct_cfg.copy_trade_interval_mins * 60)).await;
+            tokio::time::sleep(Duration::from_secs(
+                ct_state.cfg.copy_trade_interval_mins * 60,
+            ))
+            .await;
         }
     });
 
-    // Housekeeping loop — resolves copy bets independently
-    let hk_portfolio = Arc::clone(&portfolio);
-    let hk_notifier = Arc::clone(&notifier);
-    let hk_cfg = Arc::clone(&cfg);
-    let hk_http = reqwest::Client::builder()
-        .timeout(Duration::from_secs(15))
-        .build()
-        .expect("failed to build housekeeping HTTP client");
+    // Housekeeping loop — resolves copy bets + daily digest
+    let hk_state = Arc::clone(&state);
     let housekeeping_loop = tokio::spawn(async move {
         loop {
-            if let Err(e) = cycles::housekeeping_cycle(&hk_portfolio, &hk_notifier, &hk_http).await
-            {
+            if let Err(e) = cycles::housekeeping_cycle(&hk_state).await {
                 tracing::error!(err = %e, "Copy housekeeping cycle failed");
             }
-            if let Err(e) = cycles::digest::maybe_send_daily_digest(
-                &hk_http,
-                &hk_portfolio,
-                &hk_notifier,
-                &hk_cfg,
-            )
-            .await
-            {
+            if let Err(e) = cycles::digest::maybe_send_daily_digest(&hk_state).await {
                 tracing::warn!(err = %e, "Daily digest check failed");
             }
             tokio::time::sleep(Duration::from_secs(5 * 60)).await;

--- a/copy-trading-bot/src/live.rs
+++ b/copy-trading-bot/src/live.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -35,22 +36,33 @@ pub async fn broadcast(state: &AppState, message: &str) {
 
 /// Prune worker: drains permanently-failed chat_ids from the in-memory queue and
 /// deactivates them. Runs as its own task, fully separate from broadcasting.
+///
+/// Coalesces: on each wake it drains every batch currently queued into a single
+/// `HashSet`, deduping chat_ids across broadcasts and collapsing them to one DB
+/// write. Without this, a dead chat_id re-enqueued by every failing broadcast
+/// would trigger a redundant (idempotent) UPDATE per occurrence.
 pub async fn run_prune_worker(
     portfolio: Arc<PgPortfolio>,
     notifier: Arc<TelegramNotifier>,
     mut rx: UnboundedReceiver<Vec<String>>,
 ) {
-    while let Some(ids) = rx.recv().await {
+    while let Some(first) = rx.recv().await {
+        let mut ids: HashSet<String> = first.into_iter().collect();
+        // Drain anything else already queued so duplicates collapse into one call.
+        while let Ok(more) = rx.try_recv() {
+            ids.extend(more);
+        }
         if ids.is_empty() {
             continue;
         }
+        let batch: Vec<String> = ids.into_iter().collect();
         match portfolio
-            .deactivate_telegram_users(notifier.bot_kind(), &ids)
+            .deactivate_telegram_users(notifier.bot_kind(), &batch)
             .await
         {
-            Ok(_) => tracing::info!(count = ids.len(), "Deactivated unreachable subscribers"),
+            Ok(_) => tracing::info!(count = batch.len(), "Deactivated unreachable subscribers"),
             Err(e) => {
-                tracing::warn!(err = %e, count = ids.len(), "Failed to deactivate pruned subscribers")
+                tracing::warn!(err = %e, count = batch.len(), "Failed to deactivate pruned subscribers")
             }
         }
     }

--- a/copy-trading-bot/src/live.rs
+++ b/copy-trading-bot/src/live.rs
@@ -11,10 +11,21 @@ use crate::scanner::copy_trader::CopyTraderMonitor;
 use crate::storage::postgres::PgPortfolio;
 use crate::telegram::notifier::TelegramNotifier;
 
-/// Broadcast a message to the owner and all subscribers.
+/// Broadcast a message to the owner and all active subscribers, pruning any that are gone.
 pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, message: &str) {
-    let subs = portfolio.telegram_subscribers().await.unwrap_or_default();
-    notifier.broadcast(&subs, message).await;
+    let bot = notifier.bot_kind();
+    let subs = portfolio
+        .telegram_subscribers(bot)
+        .await
+        .unwrap_or_default();
+    let pruned = notifier.broadcast(&subs, message).await;
+    if !pruned.is_empty() {
+        if let Err(e) = portfolio.deactivate_telegram_users(bot, &pruned).await {
+            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers");
+        } else {
+            tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers");
+        }
+    }
 }
 
 pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
@@ -49,6 +60,7 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
     let notifier = Arc::new(TelegramNotifier::new(
         &cfg.telegram_bot_token,
         &cfg.telegram_chat_id,
+        "copy",
     ));
 
     let monitor = Arc::new(CopyTraderMonitor::new(
@@ -79,11 +91,28 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
         loop {
             let commands = cmd_notifier.poll_commands().await;
             for (chat_id, cmd, username, first_name, full_text) in &commands {
-                if let Err(e) = cmd_portfolio
-                    .upsert_telegram_user(chat_id, username.as_deref(), first_name.as_deref())
+                match cmd_portfolio
+                    .upsert_telegram_user(
+                        cmd_notifier.bot_kind(),
+                        chat_id,
+                        username.as_deref(),
+                        first_name.as_deref(),
+                    )
                     .await
                 {
-                    tracing::warn!(err = %e, "Failed to upsert telegram user");
+                    Ok(true) => {
+                        let uname = username.as_deref().unwrap_or("—");
+                        let fname = first_name.as_deref().unwrap_or("—");
+                        let _ = cmd_notifier
+                            .send(&format!(
+                                "🆕 *New user joined*\n\n\
+                                 👤 {fname} (@{uname})\n\
+                                 🆔 `{chat_id}`"
+                            ))
+                            .await;
+                    }
+                    Ok(false) => {}
+                    Err(e) => tracing::warn!(err = %e, "Failed to upsert telegram user"),
                 }
 
                 tracing::info!(cmd = cmd.as_str(), chat_id, "Handling Telegram command");
@@ -127,6 +156,7 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
     // Housekeeping loop — resolves copy bets independently
     let hk_portfolio = Arc::clone(&portfolio);
     let hk_notifier = Arc::clone(&notifier);
+    let hk_cfg = Arc::clone(&cfg);
     let hk_http = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()
@@ -136,6 +166,16 @@ pub async fn run_live(cfg: Arc<CopyTradingConfig>) -> Result<()> {
             if let Err(e) = cycles::housekeeping_cycle(&hk_portfolio, &hk_notifier, &hk_http).await
             {
                 tracing::error!(err = %e, "Copy housekeeping cycle failed");
+            }
+            if let Err(e) = cycles::digest::maybe_send_daily_digest(
+                &hk_http,
+                &hk_portfolio,
+                &hk_notifier,
+                &hk_cfg,
+            )
+            .await
+            {
+                tracing::warn!(err = %e, "Daily digest check failed");
             }
             tokio::time::sleep(Duration::from_secs(5 * 60)).await;
         }

--- a/copy-trading-bot/src/main.rs
+++ b/copy-trading-bot/src/main.rs
@@ -17,6 +17,7 @@ mod config;
 mod cycles;
 mod live;
 mod scanner;
+mod state;
 
 use anyhow::Result;
 use config::CopyTradingConfig;

--- a/copy-trading-bot/src/scanner/copy_trader.rs
+++ b/copy-trading-bot/src/scanner/copy_trader.rs
@@ -214,11 +214,13 @@ pub async fn refresh_followed_trader_stats(http: &Client, portfolio: &PgPortfoli
                 if let Err(e) = portfolio
                     .update_trader_stats(
                         &trader.proxy_wallet,
-                        stats.rank,
-                        Some(stats.pnl),
-                        pnl_month,
-                        Some(stats.volume),
-                        stats.username.as_deref(),
+                        crate::storage::copy_trade::TraderStatsUpdate {
+                            rank: stats.rank,
+                            pnl: Some(stats.pnl),
+                            pnl_month,
+                            volume: Some(stats.volume),
+                            username: stats.username.as_deref(),
+                        },
                     )
                     .await
                 {

--- a/copy-trading-bot/src/scanner/copy_trader.rs
+++ b/copy-trading-bot/src/scanner/copy_trader.rs
@@ -158,12 +158,17 @@ fn parse_trader_stats(entries: Vec<LeaderboardEntry>) -> Option<TraderStats> {
     })
 }
 
-/// Fetch all-time stats (rank, PnL, volume, username) for a single wallet via
-/// `GET /v1/leaderboard?timePeriod=ALL&limit=1&user=<wallet>`.
+/// Fetch stats (rank, PnL, volume, username) for a single wallet and time
+/// period via `GET /v1/leaderboard?timePeriod=<period>&limit=1&user=<wallet>`.
+/// `period` is one of `"ALL"`, `"MONTH"`, `"DAY"`.
 ///
 /// Returns `Ok(None)` when the wallet has no leaderboard entry.
-pub async fn fetch_trader_stats(http: &Client, wallet: &str) -> Result<Option<TraderStats>> {
-    let url = format!("{DATA_API}/v1/leaderboard?timePeriod=ALL&limit=1&user={wallet}");
+pub async fn fetch_trader_stats(
+    http: &Client,
+    wallet: &str,
+    period: &str,
+) -> Result<Option<TraderStats>> {
+    let url = format!("{DATA_API}/v1/leaderboard?timePeriod={period}&limit=1&user={wallet}");
     let entries: Vec<LeaderboardEntry> = http
         .get(&url)
         .timeout(REQUEST_TIMEOUT)
@@ -193,18 +198,25 @@ pub async fn refresh_followed_trader_stats(http: &Client, portfolio: &PgPortfoli
     };
 
     let fetches = traders.iter().map(|t| async move {
-        let res = fetch_trader_stats(http, &t.proxy_wallet).await;
-        (t, res)
+        // All-time drives rank/pnl/volume; MONTH supplies the last-month pnl.
+        // Run both period fetches concurrently to halve per-trader latency.
+        let (all, month) = tokio::join!(
+            fetch_trader_stats(http, &t.proxy_wallet, "ALL"),
+            fetch_trader_stats(http, &t.proxy_wallet, "MONTH"),
+        );
+        (t, all, month)
     });
 
-    for (trader, res) in join_all(fetches).await {
+    for (trader, res, month_res) in join_all(fetches).await {
         match res {
             Ok(Some(stats)) => {
+                let pnl_month = month_res.ok().flatten().map(|m| m.pnl);
                 if let Err(e) = portfolio
                     .update_trader_stats(
                         &trader.proxy_wallet,
                         stats.rank,
                         Some(stats.pnl),
+                        pnl_month,
                         Some(stats.volume),
                         stats.username.as_deref(),
                     )
@@ -248,7 +260,7 @@ pub async fn fetch_trader_username(http: &Client, wallet: &str) -> Option<String
 /// the top entries formatted for display.  This is **read-only** — nothing is
 /// written to the database.
 ///
-/// `time_period` must be one of `"DAY"`, `"WEEK"`, `"MONTH"`, or `"ALL"`.
+/// `time_period` must be one of `"DAY"`, `"MONTH"`, or `"ALL"`.
 ///
 /// # Errors
 ///
@@ -316,18 +328,16 @@ fn format_leaderboard_section(entries: &[LeaderboardDisplay], show_wallets: bool
     for entry in entries {
         let pnl_str = crate::format::format_dollars(entry.pnl);
         let vol_str = crate::format::format_dollars(entry.volume);
+        let link = crate::format::profile_link(&entry.name, &entry.wallet);
 
         let line = match entry.rank {
-            1 => format!("🥇 *{}* — PnL: {} | Vol: {}", entry.name, pnl_str, vol_str),
-            2 => format!("🥈 *{}* — PnL: {} | Vol: {}", entry.name, pnl_str, vol_str),
-            3 => format!("🥉 *{}* — PnL: {} | Vol: {}", entry.name, pnl_str, vol_str),
+            1 => format!("🥇 {link} — PnL: {pnl_str} | Vol: {vol_str}"),
+            2 => format!("🥈 {link} — PnL: {pnl_str} | Vol: {vol_str}"),
+            3 => format!("🥉 {link} — PnL: {pnl_str} | Vol: {vol_str}"),
             n => format!(
-                "{} {}. {} — PnL: {} | Vol: {}",
+                "{} {}. {link} — PnL: {pnl_str} | Vol: {vol_str}",
                 return_rank_str(n),
                 n,
-                entry.name,
-                pnl_str,
-                vol_str,
             ),
         };
 
@@ -382,6 +392,35 @@ pub fn format_multi_leaderboard(periods: &[(&str, &[LeaderboardDisplay])]) -> St
 #[inline]
 fn return_rank_str(_rank: usize) -> &'static str {
     " "
+}
+
+/// Format the top `n` leaderboard entries as a standalone "consider following"
+/// digest message (MONTH window). Advisory only — the reader chooses who to
+/// `/follow`; the bot never auto-follows.
+pub fn format_top_traders_digest(entries: &[LeaderboardDisplay], n: usize) -> String {
+    let top = &entries[..n.min(entries.len())];
+    if top.is_empty() {
+        return "📈 *Top Traders — This Month*\n\n_No leaderboard data available right now._"
+            .to_string();
+    }
+
+    let mut parts = vec![
+        "📈 *Top Traders — This Month*".to_string(),
+        "Consider copying — tap a name for their profile:".to_string(),
+        String::new(),
+    ];
+    for e in top {
+        let link = crate::format::profile_link(&e.name, &e.wallet);
+        let pnl = crate::format::format_dollars(e.pnl);
+        let vol = crate::format::format_dollars(e.volume);
+        parts.push(format!(
+            "{}. {link} — PnL: {pnl} | Vol: {vol}\n   `/follow {}`",
+            e.rank, e.wallet
+        ));
+    }
+    parts.push(String::new());
+    parts.push("_Advisory only — you choose who to /follow._".to_string());
+    parts.join("\n")
 }
 
 // ---------------------------------------------------------------------------
@@ -462,7 +501,7 @@ impl CopyTraderMonitor {
         let raw_count = events.len();
         let trades: Vec<TraderTrade> = parse_activity_events(events);
 
-        tracing::info!(
+        tracing::debug!(
             wallet = %wallet,
             since = %since.format("%Y-%m-%d %H:%M"),
             raw_events = raw_count,
@@ -497,7 +536,7 @@ impl CopyTraderMonitor {
                 .as_deref()
                 .unwrap_or(&trader.proxy_wallet[..8.min(trader.proxy_wallet.len())])
                 .to_string();
-            tracing::info!(
+            tracing::debug!(
                 trader = %name,
                 wallet = %trader.proxy_wallet,
                 since = %since.format("%Y-%m-%d %H:%M"),
@@ -603,6 +642,47 @@ impl CopyTraderMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn lb(rank: usize, name: &str, pnl: f64, wallet: &str) -> LeaderboardDisplay {
+        LeaderboardDisplay {
+            rank,
+            name: name.to_string(),
+            pnl,
+            volume: pnl * 5.0,
+            wallet: wallet.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_format_top_traders_digest_basic() {
+        let entries = vec![
+            lb(1, "Alice", 120_000.0, "0xabc12345def"),
+            lb(2, "Bob", 50_000.0, "0xdef67890abc"),
+            lb(3, "Carol", 10_000.0, "0x11122233"),
+        ];
+        let out = format_top_traders_digest(&entries, 2);
+        assert!(out.contains("Top Traders"));
+        assert!(out.contains("Alice"));
+        // profile link + follow hint present for the top entry
+        assert!(out.contains("polymarket.com/profile/0xabc12345def"));
+        assert!(out.contains("/follow 0xabc12345def"));
+        // truncated to n = 2
+        assert!(!out.contains("Carol"));
+    }
+
+    #[test]
+    fn test_format_top_traders_digest_empty() {
+        let out = format_top_traders_digest(&[], 5);
+        assert!(out.contains("No leaderboard data"));
+    }
+
+    #[test]
+    fn test_leaderboard_section_has_profile_link_and_follow() {
+        let entries = vec![lb(1, "Alice", 120_000.0, "0xabc12345def")];
+        let out = format_leaderboard_section(&entries, true);
+        assert!(out.contains("polymarket.com/profile/0xabc12345def"));
+        assert!(out.contains("/follow 0xabc12345def"));
+    }
 
     // Real API response shape captured 2026-03-15
     const ACTIVITY_JSON: &str = r#"[
@@ -825,7 +905,7 @@ mod tests {
     async fn test_fetch_trader_stats_live() {
         let http = Client::new();
         let wallet = "0x37c1874a60d348903594a96703e0507c518fc53a";
-        let stats = fetch_trader_stats(&http, wallet)
+        let stats = fetch_trader_stats(&http, wallet, "ALL")
             .await
             .unwrap()
             .expect("known trader should have stats");

--- a/copy-trading-bot/src/state.rs
+++ b/copy-trading-bot/src/state.rs
@@ -1,0 +1,26 @@
+//! Shared application state for the copy-trading bot.
+//!
+//! Bundles the cross-cutting dependencies (DB, notifier, HTTP client, config,
+//! trader monitor) plus the failure queue sender, so cycles/loops take a single
+//! `&AppState` instead of a growing list of individual params. Built once in
+//! `run_live`, wrapped in `Arc`, and cloned into each spawned loop.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::config::CopyTradingConfig;
+use crate::scanner::copy_trader::CopyTraderMonitor;
+use crate::storage::postgres::PgPortfolio;
+use crate::telegram::notifier::TelegramNotifier;
+
+pub struct AppState {
+    pub portfolio: Arc<PgPortfolio>,
+    pub notifier: Arc<TelegramNotifier>,
+    pub monitor: Arc<CopyTraderMonitor>,
+    pub cfg: Arc<CopyTradingConfig>,
+    pub http: reqwest::Client,
+    /// Producer end of the in-memory prune queue: permanently-failed chat_ids
+    /// from broadcasts are pushed here for the prune worker to deactivate.
+    pub fail_tx: UnboundedSender<Vec<String>>,
+}

--- a/copy-trading-bot/src/telegram/commands.rs
+++ b/copy-trading-bot/src/telegram/commands.rs
@@ -34,6 +34,7 @@ pub async fn handle_command(
                  /leaderboard — top traders\n\
                  /follow — follow a trader (owner)\n\
                  /unfollow — unfollow a trader (owner)\n\
+                 /subscribers — list subscribers (owner)\n\
                  /help — show commands"
             )
         }
@@ -88,6 +89,19 @@ pub async fn handle_command(
                 }
             }
         }
+        "subscribers" => {
+            if !notifier.is_owner(chat_id) {
+                "🔒 Only the bot owner can view subscribers.".to_string()
+            } else {
+                match portfolio.list_subscribers(notifier.bot_kind()).await {
+                    Ok(subs) => crate::format::format_subscribers(&subs),
+                    Err(e) => {
+                        tracing::warn!(err = %e, "Failed to load subscribers");
+                        "⚠️ Failed to load subscribers".to_string()
+                    }
+                }
+            }
+        }
         "follow" => {
             if !notifier.is_owner(chat_id) {
                 "🔒 Only the bot owner can follow traders.".to_string()
@@ -117,7 +131,10 @@ pub async fn handle_command(
                     {
                         tracing::warn!(err = %e, "Failed to init copy trader starting bankroll");
                     }
-                    let stats = fetch_trader_stats(http, &wallet).await.ok().flatten();
+                    let stats = fetch_trader_stats(http, &wallet, "ALL")
+                        .await
+                        .ok()
+                        .flatten();
                     let mut username = stats.as_ref().and_then(|s| s.username.clone());
                     if username.is_none() {
                         username = fetch_trader_username(http, &wallet).await;
@@ -172,6 +189,7 @@ pub async fn handle_command(
                  /leaderboard — top Polymarket traders\n\
                  /follow — follow a trader (owner)\n\
                  /unfollow — unfollow a trader (owner)\n\
+                 /subscribers — list subscribers (owner)\n\
                  /help — this message"
             .to_string(),
         _ => format!("❓ Unknown command: /{cmd}\nTry /help"),

--- a/copy-trading-bot/src/telegram/commands.rs
+++ b/copy-trading-bot/src/telegram/commands.rs
@@ -1,27 +1,23 @@
 //! Telegram command dispatch for the copy-trading bot.
 
-use crate::config::CopyTradingConfig;
 use crate::cycles::copy_trade::COPY_TRADER_STARTING_BANKROLL;
 use crate::scanner::copy_trader::{
-    CopyTraderMonitor, fetch_leaderboard, fetch_trader_stats, fetch_trader_username,
-    format_multi_leaderboard, refresh_followed_trader_stats,
+    fetch_leaderboard, fetch_trader_stats, fetch_trader_username, format_multi_leaderboard,
+    refresh_followed_trader_stats,
 };
-use crate::storage::postgres::PgPortfolio;
-use crate::telegram::notifier::TelegramNotifier;
+use crate::state::AppState;
 
 /// Dispatch a single Telegram command and return the reply string.
-#[allow(clippy::too_many_arguments)]
 pub async fn handle_command(
     cmd: &str,
     chat_id: &str,
     full_text: &str,
     first_name: Option<&str>,
-    portfolio: &PgPortfolio,
-    notifier: &TelegramNotifier,
-    _monitor: &CopyTraderMonitor,
-    http: &reqwest::Client,
-    _cfg: &CopyTradingConfig,
+    state: &AppState,
 ) -> String {
+    let portfolio = state.portfolio.as_ref();
+    let notifier = state.notifier.as_ref();
+    let http = &state.http;
     match cmd {
         "start" => {
             let name = first_name.unwrap_or("there");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,10 @@ services:
       METRICS_PORT: "9000"
     volumes:
       - model:/app/model
+    # Metrics port bound to localhost only — Prometheus scrapes it over the
+    # internal Docker network (bot:9000), so it must not be exposed publicly.
     ports:
-      - "9000:9000"
+      - "127.0.0.1:9000:9000"
     stop_grace_period: 15s
     restart: unless-stopped
 
@@ -67,8 +69,10 @@ services:
       TELEGRAM_BOT_TOKEN: ${COPY_TELEGRAM_BOT_TOKEN}
       TELEGRAM_CHAT_ID: ${COPY_TELEGRAM_CHAT_ID}
       METRICS_PORT: "9001"
+    # Localhost-only; not scraped externally (Prometheus reaches it internally
+    # if added as a target). Must not be exposed to the public internet.
     ports:
-      - "9001:9001"
+      - "127.0.0.1:9001:9001"
     stop_grace_period: 15s
     restart: unless-stopped
 

--- a/migrations/021_telegram_per_bot.sql
+++ b/migrations/021_telegram_per_bot.sql
@@ -1,0 +1,16 @@
+-- Make Telegram subscribers per-bot so each bot only messages (and prunes) its own users.
+ALTER TABLE telegram_users ADD COLUMN IF NOT EXISTS bot        TEXT NOT NULL DEFAULT 'trading';
+ALTER TABLE telegram_users ADD COLUMN IF NOT EXISTS active     BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE telegram_users ADD COLUMN IF NOT EXISTS blocked_at TIMESTAMPTZ;
+
+-- Repoint the primary key from (chat_id) to (bot, chat_id).
+ALTER TABLE telegram_users DROP CONSTRAINT IF EXISTS telegram_users_pkey;
+ALTER TABLE telegram_users ADD PRIMARY KEY (bot, chat_id);
+
+-- Backfill: existing rows default to bot='trading'. Duplicate each into 'copy'
+-- so no current subscriber silently loses messages from either bot.
+INSERT INTO telegram_users (chat_id, username, first_name, last_seen, created_at, bot, active)
+SELECT chat_id, username, first_name, last_seen, created_at, 'copy', active
+FROM telegram_users
+WHERE bot = 'trading'
+ON CONFLICT (bot, chat_id) DO NOTHING;

--- a/migrations/022_trader_pnl_month.sql
+++ b/migrations/022_trader_pnl_month.sql
@@ -1,0 +1,3 @@
+-- Store the followed trader's last-month Polymarket PnL alongside all-time pnl,
+-- for the /traders display (leaderboard timePeriod=MONTH).
+ALTER TABLE followed_traders ADD COLUMN IF NOT EXISTS pnl_month DOUBLE PRECISION;

--- a/migrations/023_reconcile_ml_global_bankroll.sql
+++ b/migrations/023_reconcile_ml_global_bankroll.sql
@@ -1,0 +1,38 @@
+-- Reconcile the ML bot's global bankroll after fixing the copy-bet global-credit
+-- drift (copy resolutions were crediting the global `bankroll` though copy entries
+-- never debited it, inflating global from ~€1.2k to ~€25k).
+--
+-- Model: the ML bot and copy bot are FULLY SEPARATE. The global `bankroll` and
+-- `starting_bankroll` track ONLY the ML strategies (aggressive/balanced/conservative).
+-- Copy strategies live entirely in their own `bankroll:copy:*` / `starting_bankroll:copy:*`
+-- keys and never touch the global keys.
+--
+-- All statements are guarded with EXISTS so this is a no-op on a fresh DB (where the
+-- per-strategy keys don't exist yet and init_strategy_bankrolls will seed them).
+
+-- 1. Global current bankroll = sum of ML per-strategy bankrolls (undo copy inflation).
+UPDATE portfolio SET value_f64 = (
+    SELECT COALESCE(SUM(value_f64), 0)
+    FROM portfolio
+    WHERE key IN ('bankroll:aggressive', 'bankroll:balanced', 'bankroll:conservative')
+)
+WHERE key = 'bankroll'
+  AND EXISTS (SELECT 1 FROM portfolio WHERE key = 'bankroll:balanced');
+
+-- 2. Per-strategy ML starting capital = 300 seed + 1000 (migration 017 top-up) = 1300.
+--    Migration 017 only touched bankroll:* and left these starting keys at 300.
+UPDATE portfolio SET value_f64 = 1300.0
+WHERE key IN ('starting_bankroll:aggressive',
+              'starting_bankroll:balanced',
+              'starting_bankroll:conservative');
+
+-- 3. Global starting_bankroll = sum of ML per-strategy starting (= 3 * 1300 = 3900).
+UPDATE portfolio SET value_f64 = (
+    SELECT COALESCE(SUM(value_f64), 0)
+    FROM portfolio
+    WHERE key IN ('starting_bankroll:aggressive',
+                  'starting_bankroll:balanced',
+                  'starting_bankroll:conservative')
+)
+WHERE key = 'starting_bankroll'
+  AND EXISTS (SELECT 1 FROM portfolio WHERE key = 'starting_bankroll:balanced');

--- a/migrations/024_topup_ml_strategies.sql
+++ b/migrations/024_topup_ml_strategies.sql
@@ -1,0 +1,37 @@
+-- Grant EUR1000 of betting capital to each ML strategy (aggressive/balanced/
+-- conservative) — they were drained (aggressive ~EUR6) and could no longer size
+-- bets. Bump BOTH bankroll and starting_bankroll so the injection is treated as
+-- capital, not profit (keeps ROI honest), then resync the ML global keys.
+--
+-- Copy strategies are untouched (ML and copy are fully separate; see migration 023).
+-- Guarded with EXISTS so this is a no-op on a fresh DB.
+
+-- 1. Add EUR1000 to each ML strategy's current bankroll.
+UPDATE portfolio SET value_f64 = value_f64 + 1000.0
+WHERE key IN ('bankroll:aggressive', 'bankroll:balanced', 'bankroll:conservative');
+
+-- 2. Add EUR1000 to each ML strategy's starting capital (injection, not profit).
+UPDATE portfolio SET value_f64 = value_f64 + 1000.0
+WHERE key IN ('starting_bankroll:aggressive',
+              'starting_bankroll:balanced',
+              'starting_bankroll:conservative');
+
+-- 3. Resync ML global bankroll = sum of ML per-strategy bankrolls.
+UPDATE portfolio SET value_f64 = (
+    SELECT COALESCE(SUM(value_f64), 0)
+    FROM portfolio
+    WHERE key IN ('bankroll:aggressive', 'bankroll:balanced', 'bankroll:conservative')
+)
+WHERE key = 'bankroll'
+  AND EXISTS (SELECT 1 FROM portfolio WHERE key = 'bankroll:balanced');
+
+-- 4. Resync ML global starting_bankroll = sum of ML per-strategy starting.
+UPDATE portfolio SET value_f64 = (
+    SELECT COALESCE(SUM(value_f64), 0)
+    FROM portfolio
+    WHERE key IN ('starting_bankroll:aggressive',
+                  'starting_bankroll:balanced',
+                  'starting_bankroll:conservative')
+)
+WHERE key = 'starting_bankroll'
+  AND EXISTS (SELECT 1 FROM portfolio WHERE key = 'starting_bankroll:balanced');

--- a/trading-bot/src/cycles/housekeeping.rs
+++ b/trading-bot/src/cycles/housekeeping.rs
@@ -68,7 +68,10 @@ pub async fn housekeeping_cycle(
                     broadcast(notifier, portfolio, &msg).await;
                     if r.won && r.cost > 0.0 && r.pnl / r.cost >= 1.5 {
                         let gif = random_victory_gif();
-                        let subs = portfolio.telegram_subscribers().await.unwrap_or_default();
+                        let subs = portfolio
+                            .telegram_subscribers(notifier.bot_kind())
+                            .await
+                            .unwrap_or_default();
                         notifier.broadcast_animation(&subs, gif).await;
                     }
                     metrics::record_resolution(&r.strategy, r.won, r.pnl);

--- a/trading-bot/src/live.rs
+++ b/trading-bot/src/live.rs
@@ -13,7 +13,7 @@ use crate::metrics;
 use crate::scanner::ws::{ActivityAlert, MarketWatcher};
 use crate::storage::postgres::PgPortfolio;
 use crate::strategy::StrategyProfile;
-use crate::telegram::notifier::TelegramNotifier;
+use crate::telegram::notifier::{BotKind, TelegramNotifier};
 
 /// Curated victory GIFs sent on winning bets.
 const VICTORY_GIFS: &[&str] = &[
@@ -49,19 +49,37 @@ pub struct ScanStats {
     pub signals_found: AtomicU64,
 }
 
-/// Broadcast a message to the owner and all active subscribers, pruning any that are gone.
+/// Broadcast a message to the owner and all active subscribers.
+///
+/// Sending and subscriber-lifecycle are separate concerns: `notifier.broadcast`
+/// only sends (and reports which chats are permanently gone); cleanup is
+/// delegated to [`prune_unreachable`], not done inline here.
 pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, message: &str) {
-    let bot = notifier.bot_kind();
     let subs = portfolio
-        .telegram_subscribers(bot)
+        .telegram_subscribers(notifier.bot_kind())
         .await
         .unwrap_or_default();
     let pruned = notifier.broadcast(&subs, message).await;
-    if !pruned.is_empty() {
-        if let Err(e) = portfolio.deactivate_telegram_users(bot, &pruned).await {
-            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers");
-        } else {
-            tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers");
+    prune_unreachable(notifier, portfolio, &pruned).await;
+}
+
+/// Deactivate subscribers that permanently failed delivery (blocked / chat not
+/// found). Separate from [`broadcast`] so subscriber lifecycle is its own unit.
+pub async fn prune_unreachable(
+    notifier: &TelegramNotifier,
+    portfolio: &PgPortfolio,
+    pruned: &[String],
+) {
+    if pruned.is_empty() {
+        return;
+    }
+    match portfolio
+        .deactivate_telegram_users(notifier.bot_kind(), pruned)
+        .await
+    {
+        Ok(_) => tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers"),
+        Err(e) => {
+            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers")
         }
     }
 }
@@ -113,7 +131,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
     let notifier = Arc::new(TelegramNotifier::new(
         &cfg.telegram_bot_token,
         &cfg.telegram_chat_id,
-        "trading",
+        BotKind::Trading,
     ));
     let scanner = Arc::new(
         crate::scanner::live::LiveScanner::new(&cfg, pool)

--- a/trading-bot/src/live.rs
+++ b/trading-bot/src/live.rs
@@ -59,8 +59,8 @@ pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, mes
         .telegram_subscribers(notifier.bot_kind())
         .await
         .unwrap_or_default();
-    let pruned = notifier.broadcast(&subs, message).await;
-    prune_unreachable(notifier, portfolio, &pruned).await;
+    let resp = notifier.broadcast(&subs, message).await;
+    prune_unreachable(notifier, portfolio, &resp.failed).await;
 }
 
 /// Deactivate subscribers that permanently failed delivery (blocked / chat not

--- a/trading-bot/src/live.rs
+++ b/trading-bot/src/live.rs
@@ -49,10 +49,21 @@ pub struct ScanStats {
     pub signals_found: AtomicU64,
 }
 
-/// Broadcast a message to the owner and all subscribers.
+/// Broadcast a message to the owner and all active subscribers, pruning any that are gone.
 pub async fn broadcast(notifier: &TelegramNotifier, portfolio: &PgPortfolio, message: &str) {
-    let subs = portfolio.telegram_subscribers().await.unwrap_or_default();
-    notifier.broadcast(&subs, message).await;
+    let bot = notifier.bot_kind();
+    let subs = portfolio
+        .telegram_subscribers(bot)
+        .await
+        .unwrap_or_default();
+    let pruned = notifier.broadcast(&subs, message).await;
+    if !pruned.is_empty() {
+        if let Err(e) = portfolio.deactivate_telegram_users(bot, &pruned).await {
+            tracing::warn!(err = %e, count = pruned.len(), "Failed to deactivate pruned subscribers");
+        } else {
+            tracing::info!(count = pruned.len(), "Deactivated unreachable subscribers");
+        }
+    }
 }
 
 /// Send a message only to the bot owner — operational noise subscribers don't need.
@@ -102,6 +113,7 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
     let notifier = Arc::new(TelegramNotifier::new(
         &cfg.telegram_bot_token,
         &cfg.telegram_chat_id,
+        "trading",
     ));
     let scanner = Arc::new(
         crate::scanner::live::LiveScanner::new(&cfg, pool)
@@ -342,12 +354,29 @@ pub async fn run_live(cfg: Arc<AppConfig>) -> Result<()> {
         loop {
             let commands = cmd_notifier.poll_commands().await;
             for (chat_id, cmd, username, first_name, full_text) in &commands {
-                // Track the user
-                if let Err(e) = cmd_portfolio
-                    .upsert_telegram_user(chat_id, username.as_deref(), first_name.as_deref())
+                // Track the user; notify the owner on a brand-new join.
+                match cmd_portfolio
+                    .upsert_telegram_user(
+                        cmd_notifier.bot_kind(),
+                        chat_id,
+                        username.as_deref(),
+                        first_name.as_deref(),
+                    )
                     .await
                 {
-                    tracing::warn!(err = %e, "Failed to upsert telegram user");
+                    Ok(true) => {
+                        let uname = username.as_deref().unwrap_or("—");
+                        let fname = first_name.as_deref().unwrap_or("—");
+                        let _ = cmd_notifier
+                            .send(&format!(
+                                "🆕 *New user joined*\n\n\
+                                 👤 {fname} (@{uname})\n\
+                                 🆔 `{chat_id}`"
+                            ))
+                            .await;
+                    }
+                    Ok(false) => {}
+                    Err(e) => tracing::warn!(err = %e, "Failed to upsert telegram user"),
                 }
 
                 tracing::info!(cmd = cmd.as_str(), chat_id, "Handling Telegram command");

--- a/trading-bot/src/scanner/live.rs
+++ b/trading-bot/src/scanner/live.rs
@@ -510,7 +510,9 @@ impl LiveScanner {
     }
 
     pub async fn fetch_price_history(&self, token_id: &str) -> Result<Vec<PriceTick>> {
-        let url = format!("{CLOB_API}/prices-history?market={token_id}&interval=max");
+        // fidelity=60 (60-min ticks) matches training (scripts/fetch_data.py) so
+        // volatility/momentum see the same tick spacing at train and serve.
+        let url = format!("{CLOB_API}/prices-history?market={token_id}&interval=max&fidelity=60");
         #[derive(serde::Deserialize)]
         struct Resp {
             history: Vec<PriceTick>,


### PR DESCRIPTION
## Summary
Bot-facing features + correctness fixes. Groups the non-ML, non-backtest changes from the 2026-08-23 investigation.

### Telegram / copy-bot
- **Per-bot subscribers** (migration 021): `telegram_users` gains `bot`/`active`/`blocked_at`; broadcasts prune chats that return 403/400 (blocked / not found) so the WARN flood stops; owner gets a "new user joined" notification.
- **`/leaderboard`** now links Polymarket profiles; new **daily top-traders digest** broadcast at a configured UTC hour.
- Followed trader's **last-month Poly PnL** shown in `/traders` (migration 022; leaderboard `MONTH` window fetched concurrently with `ALL`).
- Owner-only **`/subscribers`** command.

### Portfolio accounting
- **Copy bets no longer credit the ML global bankroll** — `place_copy_bet` never debited it, but resolve/exit credited it unconditionally, inflating global from ~€1.1k to ~€25k. ML and copy bots are now fully separate. Migration 023 reconciles the drift; migration 024 grants €1000 betting capital to each ML strategy (bumping starting too, so it's capital not profit).

### Analytics
- ROI denominator net/gross-consistent + NULL-safe (`cost + COALESCE(fee_paid,0)`).
- Per-trader PnL query joins `copy_ref->>'wallet'` (was a non-existent `proxy_wallet` key → 0 rows).

### Ops
- Metrics ports (9000/9001) bound to `127.0.0.1` — they were published to the public IP and getting scanned (the `Parse(Method)` WARN spam); Prometheus scrapes them over the internal Docker network regardless.
- Per-poll trader logs downgraded to debug; live price-history fetched at `fidelity=60`.

## Testing
cargo build/clippy/test green (15 + 56 + 105). Migrations 021–024 apply on boot via `run_migrations()`. Nothing deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)